### PR TITLE
feat: Add User-Agent header to Trino connection

### DIFF
--- a/src/client/trino.ts
+++ b/src/client/trino.ts
@@ -1,6 +1,7 @@
 import { Trino, BasicAuth, Query as TrinoQuery } from 'trino-client';
 import { Config, QueryResult } from '../types';
 import { getEndpointForSite, getTrinoPort, getCatalog } from './endpoints';
+import { version } from '../../package.json';
 
 /**
  * Trino client wrapper for Treasure Data
@@ -29,6 +30,9 @@ export class TDTrinoClient {
       auth: new BasicAuth(this.config.td_api_key),
       ssl: {
         rejectUnauthorized: true,
+      },
+      extraHeaders: {
+        'User-Agent': `td-mcp-server/${version}`,
       },
     });
   }

--- a/tests/client/trino.test.ts
+++ b/tests/client/trino.test.ts
@@ -6,6 +6,11 @@ import { Trino } from 'trino-client';
 // Mock the trino-client module
 vi.mock('trino-client');
 
+// Mock package.json to provide a version
+vi.mock('../../../package.json', () => ({
+  version: '0.1.0',
+}));
+
 describe('TDTrinoClient', () => {
   const mockConfig: Config = {
     td_api_key: 'test-api-key-12345',
@@ -55,6 +60,18 @@ describe('TDTrinoClient', () => {
           catalog: 'td',
           schema: 'information_schema', // Default schema since no database in config
           auth: expect.any(Object),
+        })
+      );
+    });
+
+    it('should include User-Agent header with version', () => {
+      new TDTrinoClient(mockConfig);
+
+      expect(Trino.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extraHeaders: {
+            'User-Agent': expect.stringMatching(/^td-mcp-server\/\d+\.\d+\.\d+$/),
+          },
         })
       );
     });


### PR DESCRIPTION
## Summary
Adds a User-Agent header to all Trino requests to identify the client as td-mcp-server with its version.

## Implementation
- Uses the `extraHeaders` option in trino-js-client ConnectionOptions
- Imports version from package.json
- Header format: `td-mcp-server/{version}` (e.g., `td-mcp-server/0.1.0`)

## Benefits
- 🔍 Easier debugging and monitoring on the server side
- 📊 Better tracking of td-mcp-server usage
- 🛠️ Helps identify client version for troubleshooting

## Testing
- Added unit test to verify User-Agent header is included
- Test validates the header format matches expected pattern
- All existing tests continue to pass

## Example
When td-mcp-server connects to Trino, it will now send:
```
User-Agent: td-mcp-server/0.1.0
```

Resolves #8

🤖 Generated with [Claude Code](https://claude.ai/code)