### PR TITLE
docs: Remove mention of TD_MCP_LOG_TO_CONSOLE from developer notes

### DIFF
--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -123,18 +123,9 @@ The MCP server exposes these tools that can be invoked through natural language:
 
 ### Debugging
 
-1. Enable console logging to see what's happening:
-   ```json
-   "env": {
-     "TD_API_KEY": "your-td-api-key-here",
-     "TD_SITE": "dev",
-     "TD_MCP_LOG_TO_CONSOLE": "true"
-   }
-   ```
+1. Check VS Code's Output panel to see logs
 
-2. Check VS Code's Output panel to see logs
-
-3. Common issues:
+2. Common issues:
    - **Authentication errors**: Verify your TD_API_KEY is correct
    - **Connection errors**: Check your TD_SITE setting
    - **Permission errors**: Ensure your API key has access to the requested databases


### PR DESCRIPTION
## Summary
Removes outdated reference to TD_MCP_LOG_TO_CONSOLE environment variable from the developer notes.

## Context
The TD_MCP_LOG_TO_CONSOLE environment variable is not implemented in the current codebase. The AuditLogger has a `logToConsole` option, but it's controlled programmatically, not through this environment variable.

## Changes
- Removed the debugging step that mentioned enabling console logging via TD_MCP_LOG_TO_CONSOLE
- Simplified the debugging section to start directly with checking VS Code's Output panel

This prevents confusion for developers who might try to use this non-existent environment variable.

🤖 Generated with [Claude Code](https://claude.ai/code)