### PR TITLE
fix: Exclude .claude directory from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ tests/
 # Development files
 .github/
 .vscode/
+.claude/
 coverage/
 *.log
 *.tgz


### PR DESCRIPTION
## Summary
- Fixes #14 by adding `.claude/` to .npmignore
- Prevents development-specific files from being included in published npm package

## Test plan
- [x] Verified with `npm pack --dry-run` that .claude files are no longer included
- [x] Confirmed package size reduced from 29.3 kB to 29.2 kB
- [x] No .claude/settings.local.json in tarball contents

🤖 Generated with [Claude Code](https://claude.ai/code)