### PR TITLE
docs: Add public preview notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 MCP (Model Context Protocol) server for Treasure Data, enabling AI assistants to query and interact with Treasure Data through a secure, controlled interface.
 
+## 🚀 Public Preview
+
+This MCP server is currently in a public preview. We're excited for you to try it out and welcome your feedback to help us improve the service.
+
+**Please note:** During this preview period, use of the server is free. However, we plan to introduce a usage-based pricing model in the future, which will be based on the number of queries issued. We will provide ample notice and detailed pricing information before any charges are implemented.
+
+Your feedback during this phase is invaluable and will help us shape the future of this tool. Thank you for being an early adopter!
+
 ## Features
 
 - 🔍 Query databases, tables, and schemas through information_schema


### PR DESCRIPTION
## Summary
- Adds a prominent public preview notice section to the README
- Clarifies the current free status and future pricing plans

## Details
The notice includes:
- 🚀 Eye-catching public preview header
- Clear statement that the service is currently free
- Information about future usage-based pricing model
- Request for user feedback during preview phase
- Acknowledgment of early adopters

## Placement
The notice is placed immediately after the main project description and before the Features section for maximum visibility.

🤖 Generated with [Claude Code](https://claude.ai/code)