### PR TITLE
docs: Clarify optional database parameters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ List all databases in your Treasure Data account.
 List all tables in a specific database.
 
 **Parameters:**
-- `database` (string, required): Database name
+- `database` (string, optional): Database name. If omitted, uses the current database context (TD_DATABASE or last used database)
 
 **Example:**
 ```json
@@ -101,7 +101,7 @@ List all tables in a specific database.
 Get schema information for a specific table.
 
 **Parameters:**
-- `database` (string, required): Database name
+- `database` (string, optional): Database name. If omitted, uses the current database context (TD_DATABASE or last used database)
 - `table` (string, required): Table name
 
 **Example:**


### PR DESCRIPTION
## Summary
- Clarifies that the `database` parameter is optional for both `list_tables` and `describe_table` tools
- Adds explanation of what happens when the parameter is omitted

## Details
The implementation in `server.ts` shows that both tools use `this.currentDatabase` as a fallback when the database parameter is not provided:
- `list_tables`: Line 231 - `const database = (args?.database as string | undefined) || this.currentDatabase;`
- `describe_table`: Line 245 - `const database = (args?.database as string | undefined) || this.currentDatabase;`

The documentation was technically correct (showing examples with and without the parameter), but marking the parameter as "required" was confusing. This change makes it clear that the parameter is optional and explains the fallback behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)