### PR TITLE
fix: Update integration test to match actual Trino error format

### DIFF
--- a/tests/integration/trino.integration.test.ts
+++ b/tests/integration/trino.integration.test.ts
@@ -201,7 +201,8 @@ describe.skipIf(!isIntegrationTest)('TDTrinoClient Integration Tests', () => {
         const errorMessage = (error as Error).message;
         // Ensure API key is not exposed in error
         expect(errorMessage).not.toContain(process.env.TD_API_KEY_DEVELOPMENT_AWS);
-        expect(errorMessage).toContain('Trino query failed');
+        // Check for syntax error in the message
+        expect(errorMessage).toContain('SYNTAX_ERROR');
       }
     });
   });


### PR DESCRIPTION
The integration test was expecting 'Trino query failed' in error messages, but the actual implementation returns the raw Trino error message which includes 'SYNTAX_ERROR'. This PR updates the test expectation to match the actual behavior.