### PR TITLE
feat: Add auto-merge workflow for Dependabot minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      
+      - name: Enable auto-merge for Dependabot PRs
+        # Only auto-merge minor and patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically merge Dependabot PRs for minor and patch updates
- Major version updates still require manual review and merge

## Details
The workflow:
1. Triggers on all pull requests
2. Checks if the PR is from Dependabot
3. Fetches Dependabot metadata to determine update type
4. Auto-merges only if it's a patch or minor version update
5. Uses GitHub's auto-merge feature which waits for all CI checks to pass

## Benefits
- Reduces maintenance burden for safe dependency updates
- Ensures dependencies stay up-to-date with security patches
- Maintains manual review for potentially breaking major updates
- Auto-merge only happens after CI passes, ensuring safety

## Configuration
- Uses `dependabot/fetch-metadata@v2` action
- Requires `contents: write` and `pull-requests: write` permissions
- Uses squash merge strategy for clean commit history

🤖 Generated with [Claude Code](https://claude.ai/code)