### PR TITLE
chore: release v0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treasuredata/mcp-server",
-      "version": "0.1.1",
-      "license": "MIT",
+      "version": "0.1.2",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "trino-client": "^0.2.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Release v0.1.2

This patch release changes the project license from MIT to Apache 2.0.

### ⚖️ License Change
- chore: Change license from MIT to Apache 2.0 (#26)
  - Replaced MIT License with Apache License 2.0
  - Updated package.json license field
  - Provides explicit patent grant and clearer contribution terms

### Release Process
After this PR is merged:
1. Create and push tag: `git tag v0.1.2 && git push origin v0.1.2`
2. The CI workflow will automatically publish to npm
3. Create GitHub release from the tag