### PR TITLE
feat: Add GitHub Action to create releases with auto-generated notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for generate-notes
+      
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            --title "${{ github.ref_name }}" \
+            --verify-tag


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically creates GitHub releases when version tags are pushed.

## Details
The workflow:
- Triggers on push of tags matching `v*.*.*` pattern
- Uses `gh release create --generate-notes` to automatically generate release notes
- Fetches full git history to ensure proper note generation
- Uses the built-in `GITHUB_TOKEN` with `contents: write` permission

## Benefits
- Eliminates manual step of creating GitHub releases after tagging
- Ensures consistent release notes based on merged PRs
- Automatically links the release to the correct tag
- GitHub's auto-generated notes include:
  - List of merged PRs since last release
  - Contributors
  - Full changelog link

## Example
When `git push origin v0.1.3` is executed, this workflow will automatically create a GitHub release with notes generated from all PRs merged since v0.1.2.

🤖 Generated with [Claude Code](https://claude.ai/code)