### PR TITLE
fix: Exclude CLAUDE.md from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,6 +22,7 @@ design/
 doc/
 examples/
 DEVELOPER_NOTES.md
+CLAUDE.md
 
 # Environment files
 .env


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md to .npmignore to prevent it from being included in the npm package
- CLAUDE.md contains development guidance for Claude AI instances and should not be distributed

## Verification
Verified with `npm pack --dry-run` that CLAUDE.md is no longer included in the package.

## Impact
- Reduces package size slightly
- Keeps internal development documentation private
- Similar to the previous fix that excluded the .claude directory

🤖 Generated with [Claude Code](https://claude.ai/code)