### PR TITLE
docs: Update license reference in README from MIT to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ For information on testing this MCP server with GitHub Copilot Chat agent mode, 
 
 ## License
 
-MIT
+Apache License 2.0
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
Updates the README to correctly reference Apache License 2.0 instead of MIT.

## Context
In PR #26, we changed the project license from MIT to Apache 2.0, but the README still referenced the old MIT license.

## Changes
- Updates the License section in README.md from "MIT" to "Apache License 2.0"

This ensures the documentation accurately reflects the current licensing terms.

🤖 Generated with [Claude Code](https://claude.ai/code)