### PR TITLE
docs: Clarify query function uses Trino SQL dialect with TD UDFs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -157,13 +157,13 @@ export class TDMcpServer {
         },
         {
           name: 'query',
-          description: 'Execute a read-only SQL query (SELECT, SHOW, DESCRIBE). For better performance on large tables, use td_interval(time, \'-30d/now\') to limit the time range.',
+          description: 'Execute a read-only SQL query (SELECT, SHOW, DESCRIBE) using Trino SQL dialect with Treasure Data UDFs. For better performance on large tables, use td_interval(time, \'-30d/now\') to limit the time range.',
           inputSchema: {
             type: 'object',
             properties: {
               sql: {
                 type: 'string',
-                description: 'The SQL query to execute. For tables with time column, consider using td_interval() or td_time_range() in WHERE clause to improve performance. Examples: td_interval(time, \'-30d/now\') for last 30 days, td_interval(time, \'-7d/now\') for last 7 days, td_interval(time, \'-1d\') for yesterday, td_interval(time, \'-1h/now\') for last hour, td_time_range(time, \'2024-01-01\', \'2024-01-31\') for specific date range.',
+                description: 'The SQL query to execute using Trino SQL dialect. Supports Treasure Data UDFs like td_interval() and td_time_range(). For tables with time column, consider using these UDFs in WHERE clause to improve performance. Examples: td_interval(time, \'-30d/now\') for last 30 days, td_interval(time, \'-7d/now\') for last 7 days, td_interval(time, \'-1d\') for yesterday, td_interval(time, \'-1h/now\') for last hour, td_time_range(time, \'2024-01-01\', \'2024-01-31\') for specific date range.',
               },
               limit: {
                 type: 'number',


### PR DESCRIPTION
## Summary
Updates the query function description to explicitly mention that it uses Trino SQL dialect and supports Treasure Data UDFs.

## Changes
- Updated main query tool description to include "using Trino SQL dialect with Treasure Data UDFs"
- Updated sql parameter description to clarify "using Trino SQL dialect" and "Supports Treasure Data UDFs"

## Rationale
Users should know:
1. The specific SQL dialect they're working with (Trino, not generic SQL)
2. That Treasure Data's custom UDFs are available for use
3. This helps with query syntax expectations and available functionality

## Impact
Better documentation for users who will interact with the MCP server, making it clear what SQL capabilities are available.

🤖 Generated with [Claude Code](https://claude.ai/code)