### PR TITLE
chore: release v0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treasuredata/mcp-server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Release v0.1.4

This patch release includes documentation improvements.

### 📚 Documentation
- docs: Update license reference in README from MIT to Apache 2.0 (#31)
  - Fixed README to correctly reference Apache License 2.0
- docs: Clarify query function uses Trino SQL dialect with TD UDFs (#32)
  - Updated MCP query tool description to mention Trino SQL dialect
  - Added reference to Treasure Data UDF support

### Release Process
After this PR is merged:
1. Create and push tag: `git tag v0.1.4 && git push origin v0.1.4`
2. The CI workflow will automatically publish to npm
3. The release workflow will automatically create a GitHub release with notes