### PR TITLE
feat: Add current_database function to show active context

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,28 @@ Switch the current database context for subsequent queries.
 
 After switching, all queries will use the new database by default unless explicitly specified.
 
+### 7. current_database
+Get the current database context being used for queries.
+
+**Parameters:**
+None
+
+**Example:**
+```json
+{
+  "name": "current_database",
+  "arguments": {}
+}
+```
+
+**Response:**
+```json
+{
+  "currentDatabase": "sample_datasets",
+  "description": "The current database context used for queries"
+}
+```
+
 ## Security
 
 - **Read-only by default**: Write operations require explicit configuration
@@ -213,6 +235,7 @@ You have access to Treasure Data through the td-mcp-server. You can:
 - Describe table schemas
 - Execute SQL queries on the data
 - Switch between databases using use_database
+- Check current database context using current_database
 
 Start by listing available databases to understand what data is available.
 ```

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,6 +203,14 @@ export class TDMcpServer {
             required: ['database'],
           },
         },
+        {
+          name: 'current_database',
+          description: 'Get the current database context being used for queries',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+          },
+        },
       ],
     }));
 
@@ -337,6 +345,20 @@ export class TDMcpServer {
               // Note: Audit logging for failures could be added here
               throw error;
             }
+          }
+
+          case 'current_database': {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    currentDatabase: this.currentDatabase,
+                    description: 'The current database context used for queries'
+                  }, null, 2),
+                },
+              ],
+            };
           }
 
           default:


### PR DESCRIPTION
## Summary
Adds a new MCP tool `current_database` that returns the current database context being used for queries.

## Details
- New tool with no parameters that returns the active database name
- Helpful for users to verify which database context they're currently using
- Complements the existing `use_database` function

## Implementation
- Added tool definition in `server.ts` with appropriate description
- Implemented handler that returns current database from `this.currentDatabase`
- Returns JSON with `currentDatabase` field and a description

## Documentation
- Added section in README with:
  - Function description
  - Example usage
  - Example response
- Updated AI assistant prompt to mention the new function

## Example Usage
```json
{
  "name": "current_database",
  "arguments": {}
}
```

Response:
```json
{
  "currentDatabase": "sample_datasets",
  "description": "The current database context used for queries"
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)