### PR TITLE
chore: release v0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treasuredata/mcp-server",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Release v0.1.5

This patch release adds a new feature for checking the current database context.

### 🚀 Features
- feat: Add current_database function to show active context (#34)
  - New MCP tool to get the current database context
  - Returns the database name currently being used for queries
  - Helpful for users to verify which database they're working with

### Release Process
After this PR is merged:
1. Create and push tag: `git tag v0.1.5 && git push origin v0.1.5`
2. The CI workflow will automatically publish to npm
3. The release workflow will automatically create a GitHub release with notes