### PR TITLE
Sanitize internal details from public documentation

### DIFF
--- a/doc/design/2025-06-09-project-design.md
+++ b/doc/design/2025-06-09-project-design.md
@@ -24,13 +24,12 @@
     - Use [api-presto.treasuredata.com](http://api-presto.treasuredata.com) REST API (Presto/Trino API). This supports listing databases/tables/schema through information_schema catalog
 	    - Use X-Trino-User: (TD_API_KEY) header for the authentication. In trino-js-client, setting user = (TD_API_KEY) will automatically set the X-Trino-User header. password can be empty.
 	    - User need to set TD_API_KEY in the mcp server configuration
-    - Depending on the site, we need to use a different endpoints. us01, jp01, eu01, ap02, ap03, and dev (internal, hidden from public documentation)
+    - Depending on the site, we need to use a different endpoints. us01, jp01, eu01, ap02, ap03
 	    - us01: api-presto.treasuredata.com
 	    - jp01: api-presto.treasuredata.co.jp
 	    - eu01: api-presto.eu01.treasuredata.com
 	    - ap02: api-presto.ap02.treasuredata.com
 	    - ap03: api-presto.ap03.treasuredata.com
-	    - dev: api-development-presto.treasuredata.com
 	- catalog name: td
 	- list of schemas (databases), list of tables can be retrieved queries against information_schema. This need to be instructed in the MCP function definition
 - chat
@@ -123,7 +122,7 @@ td-mcp-server/
 ```json
 {
   "td_api_key": "YOUR_API_KEY",
-  "site": "us01",  // Options: us01, jp01, eu01, ap02, ap03, dev
+  "site": "us01",  // Options: us01, jp01, eu01, ap02, ap03
   "enable_updates": false  // Default: false. Set to true to allow UPDATE/DELETE/INSERT operations
 }
 ```
@@ -191,31 +190,3 @@ Add to your MCP client configuration (e.g., Claude Desktop):
 3. Result caching and pagination
 4. Advanced schema exploration tools
 
-
-### How to use LLM API for chat
-
-- Find your project ID
-```
-curl -v -H "Authorization: TD1 ${TD_API_KEY}" https://llm-api.treasuredata.com/api/projects | jq '.data[] | select(.attributes.name | test(".*(pattern).*"))’
-```
-- Find your agent ID: `/api/agents?filter%5Bproject_id%5D=(project id)`
-- Create a new chat for the agent POST /api/chats
-  - request body:
-```
-{"data":{"type":"chats", "attributes":{"agentId":"(agent id)"}}}
-```
-  - Content-Type: application/vnd.api+json
-  - (chat id) can be found in the response JSON data.id field.
-
-- Start (and continue) the chat with  POST /api/chats/(chat id)/continue request with `{"input":"(message)"}` message body
-Content-Type: application/json
-- Read SSE (server-sent events) response
-  - Content-Type:  text/event-stream
-  - Example response:
-```
-data: {"content":" and values.","at":"2025-02-04T20:50:14Z"}
-
-data: {"tool_call":{"id":"toolu_bdrk_01KUwKumkjRp291pGrdVYUm2","functionName":"ask_ceo","functionArguments":"{\"question\": \"Can you explain Treasure Data's company culture and core values?\"}"},"at":"2025-02-04T20:50:15Z"}
-
-data: {"tool":{"id":"toolu_bdrk_01KUwKumkjRp291pGrdVYUm2","functionName":"ask_ceo","functionArguments":"{\"question\": \"Can you explain Treasure Data's company culture and core values?\"}","content":"Certainly! I'd be happy to explain Treasure Data's company culture and core values. As the CEO, I can share our core principles that guide our organization. Let me outline the key aspects of our culture and values:\n\n1. Mission and Vision:\nOur mission is to \"Build the Intelligent Data Foundation to improve human life.\" This reflects our commitment to managing data responsibly and using it to make a positive impact on billions of people's lives.\n\nOur vision is to \"Put Connected Customer Experiences"}}
-```

--- a/doc/plan/2025-06-09-project-setup.md
+++ b/doc/plan/2025-06-09-project-setup.md
@@ -170,8 +170,8 @@ This document outlines the step-by-step implementation plan for setting up the T
   - Security features
 - [x] Create unit tests with mock Trino responses
 - [x] Create integration tests with real Trino connection:
-  - Use site: 'dev' for testing
-  - Use TD_API_KEY_DEVELOPMENT_AWS environment variable
+  - (Internal TD only) Use site: 'dev' for testing
+  - (Internal TD only) Use TD_API_KEY_DEVELOPMENT_AWS environment variable
   - Test actual database operations
   - Test against sample_datasets (www_access, nasdaq tables)
 - [x] Add CI/CD pipeline configuration with GitHub Actions

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ This directory contains example configurations for various MCP clients.
 ### claude-desktop-config.json
 Basic configuration for Claude Desktop using npx to run the server.
 
-### development-config.json
+### local-development-config.json
 Configuration for local development with console logging enabled.
 
 ### multi-region-config.json
@@ -19,7 +19,7 @@ Example of connecting to multiple TD regions simultaneously.
 2. Replace placeholder values:
    - `your_td_api_key_here` - Your actual Treasure Data API key
    - `/path/to/td-mcp-server` - Path to your local installation
-   - `TD_SITE` - Your TD region (us01, jp01, eu01, ap02, ap03, dev)
+   - `TD_SITE` - Your TD region (us01, jp01, eu01, ap02, ap03)
 
 3. For Claude Desktop:
    - Place the configuration in `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)

--- a/examples/local-development-config.json
+++ b/examples/local-development-config.json
@@ -1,11 +1,11 @@
 {
   "mcpServers": {
-    "treasuredata-dev": {
+    "treasuredata-local": {
       "command": "node",
       "args": ["/path/to/td-mcp-server/dist/index.js"],
       "env": {
-        "TD_API_KEY": "your_development_api_key",
-        "TD_SITE": "dev",
+        "TD_API_KEY": "your_api_key_here",
+        "TD_SITE": "us01",
         "TD_ENABLE_UPDATES": "false",
         "TD_DATABASE": "sample_datasets",
         "TD_MCP_LOG_TO_CONSOLE": "true"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,5 +1,7 @@
 # Integration Tests
 
+**Note: This directory is for internal Treasure Data development only.**
+
 This directory contains integration tests that connect to a real Treasure Data environment.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- Remove internal development details from public-facing documentation
- Keep functionality intact while hiding internal infrastructure

## Changes
1. **Design documentation cleanup** (`doc/design/2025-06-09-project-design.md`):
   - Removed references to internal 'dev' site and its endpoint
   - Removed entire "How to use LLM API for chat" section which contained internal API details
   - Removed the "ask_ceo" example that revealed internal AI usage

2. **Example configuration updates**:
   - Renamed `development-config.json` to `local-development-config.json` to be more descriptive
   - Changed example from using 'dev' site to 'us01' (public site)
   - Updated examples README to remove 'dev' from list of valid sites

3. **Internal documentation marking**:
   - Added note to integration test README that it's for internal TD development only
   - Added "(Internal TD only)" notes to project setup doc where dev site is mentioned

## Important Notes
- The 'dev' site remains in the source code (`src/types.ts`, `src/client/endpoints.ts`) as it's needed for functionality
- We're just removing it from public documentation to avoid exposing internal infrastructure
- Integration tests still use the dev environment but are clearly marked as internal

## Test plan
- [x] Documentation builds correctly
- [x] Examples are valid and don't reference internal sites
- [x] Source code functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)