### PR TITLE
Release v0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
Re-release to address npm publishing issues from v0.1.7.

## Changes
- Version bump to 0.1.8

## Context
The v0.1.7 release encountered npm publishing issues, requiring a new patch release.

## Test plan
- [x] Version bump to 0.1.8
- [ ] GitHub Actions CI passes
- [ ] npm publish will succeed after merge

🤖 Generated with [Claude Code](https://claude.ai/code)