### PR TITLE
fix: Add explicit files field to fix npm README display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {
@@ -40,6 +40,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ],
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary
This PR fixes the npm package page not displaying the README by adding an explicit `files` field to package.json.

## Problem
The npm page for @treasuredata/mcp-server shows:
> ⚠️ This package does not have a README. Add a README to your package so that users know how to get started.

Even though the README.md is included in the published package tarball.

## Solution
- Add explicit `files` field in package.json to ensure npm registry properly recognizes the README
- This is a common issue where npm's registry doesn't properly index the README without explicit declaration

## Changes
- Add `files` field listing: `dist/`, `README.md`, `LICENSE`, `package.json`
- Bump version to 0.1.9

## Test plan
- [x] Verified README.md is still included in package tarball with `npm pack --dry-run`
- [x] Files field properly formatted in package.json
- [ ] After publish, npm page should display README correctly

🤖 Generated with [Claude Code](https://claude.ai/code)