### PR TITLE
fix: Ensure README is properly displayed on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {
@@ -17,7 +17,9 @@
     "test:unit": "vitest run --exclude tests/integration",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write src/**/*.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepare": "npm run build",
+    "prepack": "cp README.md LICENSE package.json dist/ 2>/dev/null || true"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
This PR fixes the npm registry not displaying the README on the package page, even though the README.md file is included in the published package.

## Problem
- npm package page shows: "⚠️ This package does not have a README"
- The README.md file IS included in the npm package tarball
- But `npm view @treasuredata/mcp-server readme` returns the content while the registry API returns `null`

## Root Cause
The issue occurs because npm's registry doesn't properly index the README when:
1. The package is built before publishing
2. The publish process might not have the README in the expected location

## Solution
Added two npm scripts:
1. `"prepare": "npm run build"` - Ensures the package is built before publishing
2. `"prepack": "cp README.md LICENSE package.json dist/ 2>/dev/null || true"` - Copies README to dist folder before packing

This ensures the README is available in both the root and dist directories during the publish process.

## Changes
- Add prepare and prepack scripts to package.json
- Bump version to 0.1.11

## Test plan
- [x] Verified npm pack includes README.md
- [ ] After publish, npm registry should display README correctly
- [ ] CI/CD publish process should work without issues

🤖 Generated with [Claude Code](https://claude.ai/code)