### PR TITLE
fix: Hide 'dev' site from error messages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -49,8 +49,10 @@ export function validateConfig(config: Config): void {
 
   // Validate site
   if (!VALID_SITES.includes(config.site)) {
+    // Don't expose 'dev' site in error messages
+    const publicSites = VALID_SITES.filter(site => site !== 'dev');
     throw new ConfigurationError(
-      `Invalid TD_SITE: ${config.site}. Must be one of: ${VALID_SITES.join(', ')}`
+      `Invalid TD_SITE: ${config.site}. Must be one of: ${publicSites.join(', ')}`
     );
   }
 

--- a/tests/config-error-messages.test.ts
+++ b/tests/config-error-messages.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { validateConfig } from '../src/config';
+
+describe('Configuration Error Messages', () => {
+  it('should not expose dev site in error messages', () => {
+    const config = {
+      td_api_key: 'test-api-key-12345',
+      site: 'invalid-site' as any,
+      enable_updates: false,
+    };
+
+    try {
+      validateConfig(config);
+      expect.fail('Should have thrown an error');
+    } catch (error: any) {
+      // Error message should list public sites but not 'dev'
+      expect(error.message).toContain('us01');
+      expect(error.message).toContain('jp01');
+      expect(error.message).toContain('eu01');
+      expect(error.message).toContain('ap02');
+      expect(error.message).toContain('ap03');
+      expect(error.message).not.toContain('dev');
+      
+      // Verify the exact format
+      expect(error.message).toBe(
+        'Invalid TD_SITE: invalid-site. Must be one of: us01, jp01, eu01, ap02, ap03'
+      );
+    }
+  });
+
+  it('should still accept dev as a valid site internally', () => {
+    const config = {
+      td_api_key: 'test-api-key-12345',
+      site: 'dev' as any,
+      enable_updates: false,
+    };
+
+    // Should not throw - dev is still valid internally
+    expect(() => validateConfig(config)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Overview
Prevents the internal 'dev' site from being exposed in error messages when users provide an invalid TD_SITE value.

## Changes
- Modified `validateConfig()` to filter out 'dev' from the list of valid sites shown in error messages
- The 'dev' site still works internally for development/testing but isn't shown to end users
- Added specific test to verify this behavior

## Example
Before:
```
Invalid TD_SITE: staging. Must be one of: us01, jp01, eu01, ap02, ap03, dev
```

After:
```
Invalid TD_SITE: staging. Must be one of: us01, jp01, eu01, ap02, ap03
```

## Testing
- All existing tests pass
- Added new test specifically for error message formatting
- Verified 'dev' site still works internally

🤖 Generated with [Claude Code](https://claude.ai/code)