### PR TITLE
feat: Mark CDP tools as experimental

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ The MCP tools use specific information_schema queries:
 - Trino errors should be caught and wrapped with user-friendly messages
 - All errors must mask sensitive data before returning to user
 
-### CDP Integration
-The CDP (Customer Data Platform) integration provides access to segments and activations:
+### CDP Integration (Experimental)
+The CDP (Customer Data Platform) integration is currently experimental and provides basic access to segments and activations:
 - **Authentication**: Uses the same TD API key with `TD1` prefix in Authorization header
 - **Endpoints**: CDP endpoints follow the same site pattern (e.g., `api-cdp.treasuredata.com` for us01)
 - **Response Format**: CDP API returns JSON:API formatted responses that need special handling
@@ -75,6 +75,7 @@ The CDP (Customer Data Platform) integration provides access to segments and act
   - `get_parent_segment`: Gets details of a specific parent segment
   - `list_segments`: Lists segments under a parent
   - `list_activations`: Lists activations (syndications) for a segment
+- **Note**: Current implementation is read-only. Write operations (create/update/delete segments) and other advanced features are not yet implemented.
 
 ## Current Implementation Status
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your feedback during this phase is invaluable and will help us shape the future 
 - 🔒 Security-first design with read-only mode by default
 - 🌍 Multi-site support (US, JP, EU, AP regions)
 - 🚀 Zero-install execution via npx
-- 🎯 CDP (Customer Data Platform) integration for segment and activation management
+- 🎯 CDP (Customer Data Platform) integration for segment and activation management (Experimental)
 
 ## Prerequisites
 
@@ -245,7 +245,9 @@ None
 }
 ```
 
-### CDP Tools (Customer Data Platform)
+### CDP Tools (Customer Data Platform) - EXPERIMENTAL
+
+**Note:** CDP tools are currently experimental and may not cover all use cases. Additional functionality will be added based on user feedback.
 
 The following tools are available for interacting with Treasure Data's Customer Data Platform (CDP):
 

--- a/src/tools/cdp/getParentSegment.ts
+++ b/src/tools/cdp/getParentSegment.ts
@@ -8,7 +8,7 @@ const inputSchema = z.object({
 
 export const getParentSegmentTool = {
   name: 'get_parent_segment',
-  description: 'Get details of a specific parent segment from TD-CDP API',
+  description: '[EXPERIMENTAL] Get details of a specific parent segment from TD-CDP API',
   schema: {
     input: {
       type: 'object',

--- a/src/tools/cdp/listActivations.ts
+++ b/src/tools/cdp/listActivations.ts
@@ -9,7 +9,7 @@ const inputSchema = z.object({
 
 export const listActivationsTool = {
   name: 'list_activations',
-  description: 'Retrieve activation list under a specific segment from TD-CDP API',
+  description: '[EXPERIMENTAL] Retrieve activation list under a specific segment from TD-CDP API',
   schema: {
     input: {
       type: 'object',

--- a/src/tools/cdp/listParentSegments.ts
+++ b/src/tools/cdp/listParentSegments.ts
@@ -4,7 +4,7 @@ import { loadConfig } from '../../config';
 
 export const listParentSegmentsTool = {
   name: 'list_parent_segments',
-  description: 'Retrieve parent segment list from TD-CDP API',
+  description: '[EXPERIMENTAL] Retrieve parent segment list from TD-CDP API',
   schema: {
     input: {
       type: 'object',

--- a/src/tools/cdp/listSegments.ts
+++ b/src/tools/cdp/listSegments.ts
@@ -8,7 +8,7 @@ const inputSchema = z.object({
 
 export const listSegmentsTool = {
   name: 'list_segments',
-  description: 'Retrieve segment list under a specific parent segment from TD-CDP API',
+  description: '[EXPERIMENTAL] Retrieve segment list under a specific parent segment from TD-CDP API',
   schema: {
     input: {
       type: 'object',

--- a/tests/tools/cdp/listParentSegments.test.ts
+++ b/tests/tools/cdp/listParentSegments.test.ts
@@ -18,7 +18,7 @@ describe('listParentSegmentsTool', () => {
 
   it('should have correct metadata', () => {
     expect(listParentSegmentsTool.name).toBe('list_parent_segments');
-    expect(listParentSegmentsTool.description).toBe('Retrieve parent segment list from TD-CDP API');
+    expect(listParentSegmentsTool.description).toBe('[EXPERIMENTAL] Retrieve parent segment list from TD-CDP API');
     expect(listParentSegmentsTool.schema.input).toEqual({
       type: 'object',
       properties: {},


### PR DESCRIPTION
## Overview
Marks all CDP tools as experimental to set proper expectations about their current state and functionality.

## Changes
- Added `[EXPERIMENTAL]` prefix to all 4 CDP tool descriptions
- Updated README to indicate CDP tools are experimental with a note
- Added clarification about missing functionality in CLAUDE.md
- Updated test to match new description

## Why?
CDP tools currently only support read operations. Core use cases like creating/updating/deleting segments, managing folders, and other advanced CDP features are not yet implemented. Marking them as experimental helps set proper expectations.

## Documentation Updates
### README
- Added "EXPERIMENTAL" to CDP tools section header
- Added note about tools being experimental and functionality being added based on feedback
- Added "(Experimental)" to the CDP feature in the features list

### CLAUDE.md
- Updated CDP Integration header to include "(Experimental)"
- Added note about current limitations: read-only operations, no write support yet

🤖 Generated with [Claude Code](https://claude.ai/code)