### PR TITLE
Release v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treasuredata/mcp-server",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,7 +41,7 @@ export class TDMcpServer {
     this.server = new Server(
       {
         name: 'td-mcp-server',
-        version: '0.2.2',
+        version: '0.3.0',
       },
       {
         capabilities: {


### PR DESCRIPTION
## Release v0.3.0

### New Features
- **CDP SQL Generation Tools** (#55)
  - Added `parent_segment_sql` tool to get SQL statements for parent segments
  - Added `segment_sql` tool to get SQL statements for segments with filtering conditions
  - Added `get_segment` tool to get detailed segment information including rules

### Improvements
- **Improved CDP tool naming consistency** (#56)
  - Renamed `audience_sql` to `parent_segment_sql` for better clarity
  - Standardized parameter naming: all CDP tools now use `parent_segment_id` instead of `audience_id`
  - Updated documentation and error messages for consistency

### Breaking Changes
- CDP tool `audience_sql` has been renamed to `parent_segment_sql`
- CDP tool parameters changed from `audience_id` to `parent_segment_id` in:
  - `parent_segment_sql` (formerly `audience_sql`)
  - `segment_sql`
  - `get_segment`

### Version Bump
- Updated version from 0.2.2 to 0.3.0