### PR TITLE
fix: Improve CDP tool parameter clarity and consistency

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -224,22 +224,22 @@ export class TDMcpServer {
         {
           name: listParentSegmentsTool.name,
           description: listParentSegmentsTool.description,
-          inputSchema: listParentSegmentsTool.schema.input,
+          inputSchema: listParentSegmentsTool.inputSchema,
         },
         {
           name: getParentSegmentTool.name,
           description: getParentSegmentTool.description,
-          inputSchema: getParentSegmentTool.schema.input,
+          inputSchema: getParentSegmentTool.inputSchema,
         },
         {
           name: listSegmentsTool.name,
           description: listSegmentsTool.description,
-          inputSchema: listSegmentsTool.schema.input,
+          inputSchema: listSegmentsTool.inputSchema,
         },
         {
           name: listActivationsTool.name,
           description: listActivationsTool.description,
-          inputSchema: listActivationsTool.schema.input,
+          inputSchema: listActivationsTool.inputSchema,
         },
         {
           name: parentSegmentSql.name,

--- a/src/tools/cdp/getParentSegment.ts
+++ b/src/tools/cdp/getParentSegment.ts
@@ -3,20 +3,21 @@ import { createCDPClient } from '../../client/cdp';
 import { loadConfig } from '../../config';
 
 const inputSchema = z.object({
-  parent_segment_id: z.number().int().positive()
+  parent_segment_id: z.number().int().positive().describe('The parent segment ID to retrieve details for')
 });
 
 export const getParentSegmentTool = {
   name: 'get_parent_segment',
-  description: '[EXPERIMENTAL] Get details of a specific parent segment from TD-CDP API',
-  schema: {
-    input: {
-      type: 'object',
-      properties: {
-        parent_segment_id: { type: 'integer', description: 'The ID of the parent segment to retrieve' }
-      },
-      required: ['parent_segment_id']
-    }
+  description: '[EXPERIMENTAL] Get details of a specific parent segment by its ID. Requires parent_segment_id parameter. Use list_parent_segments first to find available parent segment IDs.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      parent_segment_id: { 
+        type: 'integer', 
+        description: 'The parent segment ID to retrieve details for (required). Use list_parent_segments to find available IDs.' 
+      }
+    },
+    required: ['parent_segment_id']
   },
   handler: async (args: unknown, _context: unknown) => {
     const config = loadConfig();

--- a/src/tools/cdp/getSegment.ts
+++ b/src/tools/cdp/getSegment.ts
@@ -11,7 +11,7 @@ type GetSegmentInput = z.infer<typeof getSegmentSchema>;
 
 export const getSegment = {
   name: 'get_segment',
-  description: '[EXPERIMENTAL] Get detailed information about a specific segment',
+  description: '[EXPERIMENTAL] Get detailed information about a specific segment including its filtering rules. Requires both parent_segment_id and segment_id parameters. Use list_parent_segments and list_segments first to find available IDs.',
   inputSchema: getSegmentSchema,
   
   async execute(args: GetSegmentInput) {

--- a/src/tools/cdp/listActivations.ts
+++ b/src/tools/cdp/listActivations.ts
@@ -3,22 +3,26 @@ import { createCDPClient } from '../../client/cdp';
 import { loadConfig } from '../../config';
 
 const inputSchema = z.object({
-  parent_segment_id: z.number().int().positive(),
-  segment_id: z.number().int().positive()
+  parent_segment_id: z.number().int().positive().describe('The parent segment ID'),
+  segment_id: z.number().int().positive().describe('The segment ID')
 });
 
 export const listActivationsTool = {
   name: 'list_activations',
-  description: '[EXPERIMENTAL] Retrieve activation list under a specific segment from TD-CDP API',
-  schema: {
-    input: {
-      type: 'object',
-      properties: {
-        parent_segment_id: { type: 'integer', description: 'The ID of the parent segment' },
-        segment_id: { type: 'integer', description: 'The ID of the segment' }
+  description: '[EXPERIMENTAL] List all activations (syndications) for a specific segment. Requires both parent_segment_id and segment_id parameters. Use list_parent_segments and list_segments first to find available IDs.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      parent_segment_id: { 
+        type: 'integer', 
+        description: 'The parent segment ID (required). Use list_parent_segments to find available IDs.' 
       },
-      required: ['parent_segment_id', 'segment_id']
-    }
+      segment_id: { 
+        type: 'integer', 
+        description: 'The segment ID (required). Use list_segments to find available IDs under the parent segment.' 
+      }
+    },
+    required: ['parent_segment_id', 'segment_id']
   },
   handler: async (args: unknown, _context: unknown) => {
     const config = loadConfig();

--- a/src/tools/cdp/listParentSegments.ts
+++ b/src/tools/cdp/listParentSegments.ts
@@ -4,13 +4,11 @@ import { loadConfig } from '../../config';
 
 export const listParentSegmentsTool = {
   name: 'list_parent_segments',
-  description: '[EXPERIMENTAL] Retrieve parent segment list from TD-CDP API',
-  schema: {
-    input: {
-      type: 'object',
-      properties: {},
-      required: []
-    }
+  description: '[EXPERIMENTAL] List all parent segments (audiences) in Customer Data Platform. No parameters required.',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+    required: []
   },
   handler: async (_args: unknown, _context: unknown) => {
     const config = loadConfig();

--- a/src/tools/cdp/listSegments.ts
+++ b/src/tools/cdp/listSegments.ts
@@ -3,20 +3,21 @@ import { createCDPClient } from '../../client/cdp';
 import { loadConfig } from '../../config';
 
 const inputSchema = z.object({
-  parent_segment_id: z.number().int().positive()
+  parent_segment_id: z.number().int().positive().describe('The parent segment ID to list segments for')
 });
 
 export const listSegmentsTool = {
   name: 'list_segments',
-  description: '[EXPERIMENTAL] Retrieve segment list under a specific parent segment from TD-CDP API',
-  schema: {
-    input: {
-      type: 'object',
-      properties: {
-        parent_segment_id: { type: 'integer', description: 'The ID of the parent segment' }
-      },
-      required: ['parent_segment_id']
-    }
+  description: '[EXPERIMENTAL] List all segments under a specific parent segment. Requires parent_segment_id parameter. Use list_parent_segments first to find available parent segment IDs.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      parent_segment_id: { 
+        type: 'integer', 
+        description: 'The parent segment ID to list segments for (required). Use list_parent_segments to find available IDs.' 
+      }
+    },
+    required: ['parent_segment_id']
   },
   handler: async (args: unknown, _context: unknown) => {
     const config = loadConfig();

--- a/src/tools/cdp/parentSegmentSql.ts
+++ b/src/tools/cdp/parentSegmentSql.ts
@@ -10,7 +10,7 @@ type ParentSegmentSqlInput = z.infer<typeof parentSegmentSqlSchema>;
 
 export const parentSegmentSql = {
   name: 'parent_segment_sql',
-  description: '[EXPERIMENTAL] Get the SQL statement for a parent segment',
+  description: '[EXPERIMENTAL] Get the SQL statement for a parent segment (audience). Requires parent_segment_id parameter. Use list_parent_segments first to find available parent segment IDs.',
   inputSchema: parentSegmentSqlSchema,
   
   async execute(args: ParentSegmentSqlInput) {

--- a/src/tools/cdp/segmentSql.ts
+++ b/src/tools/cdp/segmentSql.ts
@@ -11,7 +11,7 @@ type SegmentSqlInput = z.infer<typeof segmentSqlSchema>;
 
 export const segmentSql = {
   name: 'segment_sql',
-  description: '[EXPERIMENTAL] Get the SQL statement for a segment with filtering conditions applied to the parent segment SQL',
+  description: '[EXPERIMENTAL] Get the SQL statement for a segment with filtering conditions applied to the parent segment (audience) SQL. Requires both parent_segment_id and segment_id parameters. Use list_parent_segments and list_segments first to find available IDs.',
   inputSchema: segmentSqlSchema,
   
   async execute(args: SegmentSqlInput) {

--- a/tests/tools/cdp/listParentSegments.test.ts
+++ b/tests/tools/cdp/listParentSegments.test.ts
@@ -18,8 +18,8 @@ describe('listParentSegmentsTool', () => {
 
   it('should have correct metadata', () => {
     expect(listParentSegmentsTool.name).toBe('list_parent_segments');
-    expect(listParentSegmentsTool.description).toBe('[EXPERIMENTAL] Retrieve parent segment list from TD-CDP API');
-    expect(listParentSegmentsTool.schema.input).toEqual({
+    expect(listParentSegmentsTool.description).toBe('[EXPERIMENTAL] List all parent segments (audiences) in Customer Data Platform. No parameters required.');
+    expect(listParentSegmentsTool.inputSchema).toEqual({
       type: 'object',
       properties: {},
       required: []


### PR DESCRIPTION
## Summary
- Improve CDP tool descriptions to explicitly mention required parameters
- Use consistent parameter naming across all CDP tools (schema.input → inputSchema)
- Help LLMs better understand parameter requirements by mentioning to use list_parent_segments first

## Changes
- Updated all CDP tool descriptions to explicitly state which parameters are required
- Added guidance to use `list_parent_segments` first when `parent_segment_id` is required
- Changed `schema.input` to `inputSchema` for consistency with other tools
- Updated server.ts to use the new `inputSchema` property

## Why
The `get_parent_segment` tool often failed to communicate the `parent_segment_id` parameter requirement to LLMs. By making the descriptions more explicit and consistent, LLMs will better understand what parameters each tool requires.

## Test plan
- [x] All tests pass
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>