### PR TITLE
feat: Implement workflow MCP functions for Digdag monitoring

### DIFF
--- a/src/client/workflow/client.ts
+++ b/src/client/workflow/client.ts
@@ -1,0 +1,256 @@
+import { TDSite } from '../../types.js';
+import { maskApiKey } from '../../config.js';
+import { getWorkflowEndpoint } from './endpoints.js';
+import type {
+  WorkflowListResponse,
+  SessionListResponse,
+  AttemptsResponse,
+  TasksResponse,
+  LogsResponse,
+  AttemptLogsResponse,
+  KillAttemptResponse,
+  RetrySessionResponse,
+  RetryAttemptResponse,
+  WorkflowStatus,
+  LogLevel,
+} from '../../types/workflow.js';
+
+export interface WorkflowClientOptions {
+  apiKey: string;
+  site: TDSite;
+  timeout?: number;
+}
+
+export class WorkflowClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly timeout: number;
+
+  constructor(options: WorkflowClientOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = getWorkflowEndpoint(options.site);
+    this.timeout = options.timeout || 30000; // 30 seconds default
+  }
+
+  /**
+   * Make an HTTP request to the workflow API
+   */
+  private async request<T>(
+    method: string,
+    path: string,
+    params?: Record<string, unknown>,
+    body?: unknown
+  ): Promise<T> {
+    const url = new URL(`${this.baseUrl}${path}`);
+    
+    // Add query parameters
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          url.searchParams.append(key, String(value));
+        }
+      });
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(url.toString(), {
+        method,
+        headers: {
+          'Authorization': `TD1 ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        throw new Error(
+          `Workflow API error (${response.status}): ${errorText}`
+        );
+      }
+
+      return await response.json() as T;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      
+      // Mask API key in error messages
+      if (error instanceof Error) {
+        error.message = error.message.replace(this.apiKey, maskApiKey(this.apiKey));
+      }
+      
+      throw error;
+    }
+  }
+
+  /**
+   * List all workflows in a project
+   */
+  async listWorkflows(params: {
+    project_name: string;
+    limit?: number;
+    last_id?: string;
+  }): Promise<WorkflowListResponse> {
+    return this.request<WorkflowListResponse>(
+      'GET',
+      `/api/projects/${encodeURIComponent(params.project_name)}/workflows`,
+      {
+        page_size: params.limit,
+        last_id: params.last_id,
+      }
+    );
+  }
+
+  /**
+   * List workflow sessions with filtering
+   */
+  async listSessions(params: {
+    project_name?: string;
+    workflow_name?: string;
+    status?: WorkflowStatus;
+    from_time?: string;
+    to_time?: string;
+    limit?: number;
+    last_id?: string;
+  }): Promise<SessionListResponse> {
+    const path = params.project_name && params.workflow_name
+      ? `/api/projects/${encodeURIComponent(params.project_name)}/workflows/${encodeURIComponent(params.workflow_name)}/sessions`
+      : '/api/sessions';
+
+    return this.request<SessionListResponse>(
+      'GET',
+      path,
+      {
+        status: params.status,
+        from_time: params.from_time,
+        to_time: params.to_time,
+        page_size: params.limit,
+        last_id: params.last_id,
+      }
+    );
+  }
+
+  /**
+   * Get attempts for a session
+   */
+  async getSessionAttempts(sessionId: string): Promise<AttemptsResponse> {
+    return this.request<AttemptsResponse>(
+      'GET',
+      `/api/sessions/${sessionId}/attempts`
+    );
+  }
+
+  /**
+   * Get tasks within an attempt
+   */
+  async getAttemptTasks(attemptId: string, includeSubtasks = true): Promise<TasksResponse> {
+    return this.request<TasksResponse>(
+      'GET',
+      `/api/attempts/${attemptId}/tasks`,
+      {
+        include_subtasks: includeSubtasks,
+      }
+    );
+  }
+
+  /**
+   * Get logs for a specific task
+   */
+  async getTaskLogs(params: {
+    attempt_id: string;
+    task_name: string;
+    offset?: number;
+    limit?: number;
+  }): Promise<LogsResponse> {
+    return this.request<LogsResponse>(
+      'GET',
+      `/api/attempts/${params.attempt_id}/tasks/${encodeURIComponent(params.task_name)}/logs`,
+      {
+        offset: params.offset,
+        limit: params.limit,
+      }
+    );
+  }
+
+  /**
+   * Get aggregated logs for an attempt
+   */
+  async getAttemptLogs(params: {
+    attempt_id: string;
+    task_filter?: string;
+    level_filter?: LogLevel;
+    offset?: number;
+    limit?: number;
+  }): Promise<AttemptLogsResponse> {
+    return this.request<AttemptLogsResponse>(
+      'GET',
+      `/api/attempts/${params.attempt_id}/logs`,
+      {
+        task_filter: params.task_filter,
+        level_filter: params.level_filter,
+        offset: params.offset,
+        limit: params.limit,
+      }
+    );
+  }
+
+  /**
+   * Kill a running attempt
+   */
+  async killAttempt(attemptId: string, reason?: string): Promise<KillAttemptResponse> {
+    return this.request<KillAttemptResponse>(
+      'POST',
+      `/api/attempts/${attemptId}/kill`,
+      undefined,
+      {
+        reason,
+      }
+    );
+  }
+
+  /**
+   * Retry a failed session
+   */
+  async retrySession(params: {
+    session_id: string;
+    from_task?: string;
+    retry_params?: Record<string, unknown>;
+  }): Promise<RetrySessionResponse> {
+    return this.request<RetrySessionResponse>(
+      'POST',
+      `/api/sessions/${params.session_id}/retry`,
+      undefined,
+      {
+        from_task: params.from_task,
+        params: params.retry_params,
+      }
+    );
+  }
+
+  /**
+   * Retry a specific attempt
+   */
+  async retryAttempt(params: {
+    attempt_id: string;
+    resume_from?: string;
+    retry_params?: Record<string, unknown>;
+    force?: boolean;
+  }): Promise<RetryAttemptResponse> {
+    return this.request<RetryAttemptResponse>(
+      'POST',
+      `/api/attempts/${params.attempt_id}/retry`,
+      undefined,
+      {
+        resume_from: params.resume_from,
+        params: params.retry_params,
+        force: params.force,
+      }
+    );
+  }
+}

--- a/src/client/workflow/endpoints.ts
+++ b/src/client/workflow/endpoints.ts
@@ -1,0 +1,43 @@
+import { TDSite } from '../../types.js';
+
+/**
+ * Maps TD sites to workflow API endpoints
+ * Pattern: /\Aapi(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?((?:eu01|ap02|ap03)\.)?treasuredata\.(com|co\.jp)\z/i
+ * Transform: https://api#{$1}-workflow#{$2}.#{$3}#{$4}treasuredata.#{$5}
+ */
+export const WORKFLOW_ENDPOINTS: Record<TDSite, string> = {
+  us01: 'https://api-workflow.treasuredata.com',
+  jp01: 'https://api-workflow.treasuredata.co.jp',
+  eu01: 'https://api-workflow.eu01.treasuredata.com',
+  ap02: 'https://api-workflow.ap02.treasuredata.com',
+  ap03: 'https://api-workflow.ap03.treasuredata.com',
+  dev: 'https://api-development-workflow.connect.treasuredata.com',
+};
+
+/**
+ * Get workflow API endpoint for a given site
+ */
+export function getWorkflowEndpoint(site: TDSite): string {
+  const endpoint = WORKFLOW_ENDPOINTS[site];
+  if (!endpoint) {
+    throw new Error(`Unsupported TD site: ${site}`);
+  }
+  return endpoint;
+}
+
+/**
+ * Transform a base API endpoint to workflow endpoint
+ * This handles custom staging/development endpoints with suffixes
+ */
+export function transformToWorkflowEndpoint(apiEndpoint: string): string {
+  const regex = /^api(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?((?:eu01|ap02|ap03)\.)?treasuredata\.(com|co\.jp)$/i;
+  const match = apiEndpoint.match(regex);
+  
+  if (!match) {
+    throw new Error(`Invalid API endpoint format: ${apiEndpoint}`);
+  }
+  
+  const [, envPrefix, suffix, connectDomain, regionPrefix, tld] = match;
+  
+  return `https://api${envPrefix || ''}-workflow${suffix || ''}.${connectDomain || ''}${regionPrefix || ''}treasuredata.${tld}`;
+}

--- a/src/client/workflow/endpoints.ts
+++ b/src/client/workflow/endpoints.ts
@@ -39,5 +39,5 @@ export function transformToWorkflowEndpoint(apiEndpoint: string): string {
   
   const [, envPrefix, suffix, connectDomain, regionPrefix, tld] = match;
   
-  return `https://api${envPrefix || ''}-workflow${suffix || ''}.${connectDomain || ''}${regionPrefix || ''}treasuredata.${tld}`;
+  return `https://api${envPrefix || ''}-workflow${suffix || ''}.${connectDomain || ''}${regionPrefix || ''}treasuredata.${tld}`.toLowerCase();
 }

--- a/src/client/workflow/index.ts
+++ b/src/client/workflow/index.ts
@@ -1,0 +1,3 @@
+export { WorkflowClient, type WorkflowClientOptions } from './client.js';
+export { getWorkflowEndpoint, transformToWorkflowEndpoint, WORKFLOW_ENDPOINTS } from './endpoints.js';
+export * from '../../types/workflow.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,17 @@ import {
   segmentSql,
   getSegment
 } from './tools/cdp';
+import {
+  listWorkflows,
+  listSessions,
+  getSessionAttempts,
+  getAttemptTasks,
+  getTaskLogs,
+  getAttemptLogs,
+  killAttempt,
+  retrySession,
+  retryAttempt
+} from './tools/workflow';
 
 /**
  * Treasure Data MCP Server implementation
@@ -256,6 +267,52 @@ export class TDMcpServer {
           description: getSegment.description,
           inputSchema: getSegment.inputSchema,
         },
+        // Workflow Tools
+        {
+          name: listWorkflows.name,
+          description: listWorkflows.description,
+          inputSchema: listWorkflows.inputSchema,
+        },
+        {
+          name: listSessions.name,
+          description: listSessions.description,
+          inputSchema: listSessions.inputSchema,
+        },
+        {
+          name: getSessionAttempts.name,
+          description: getSessionAttempts.description,
+          inputSchema: getSessionAttempts.inputSchema,
+        },
+        {
+          name: getAttemptTasks.name,
+          description: getAttemptTasks.description,
+          inputSchema: getAttemptTasks.inputSchema,
+        },
+        {
+          name: getTaskLogs.name,
+          description: getTaskLogs.description,
+          inputSchema: getTaskLogs.inputSchema,
+        },
+        {
+          name: getAttemptLogs.name,
+          description: getAttemptLogs.description,
+          inputSchema: getAttemptLogs.inputSchema,
+        },
+        {
+          name: killAttempt.name,
+          description: killAttempt.description,
+          inputSchema: killAttempt.inputSchema,
+        },
+        {
+          name: retrySession.name,
+          description: retrySession.description,
+          inputSchema: retrySession.inputSchema,
+        },
+        {
+          name: retryAttempt.name,
+          description: retryAttempt.description,
+          inputSchema: retryAttempt.inputSchema,
+        },
       ],
     }));
 
@@ -468,6 +525,115 @@ export class TDMcpServer {
           case getSegment.name: {
             const result = await getSegment.execute(args as any || {});
             return result;
+          }
+
+          // Workflow Tools
+          case listWorkflows.name: {
+            const result = await listWorkflows.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case listSessions.name: {
+            const result = await listSessions.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case getSessionAttempts.name: {
+            const result = await getSessionAttempts.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case getAttemptTasks.name: {
+            const result = await getAttemptTasks.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case getTaskLogs.name: {
+            const result = await getTaskLogs.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case getAttemptLogs.name: {
+            const result = await getAttemptLogs.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case killAttempt.name: {
+            const result = await killAttempt.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case retrySession.name: {
+            const result = await retrySession.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          }
+
+          case retryAttempt.name: {
+            const result = await retryAttempt.handler(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
           }
 
           default:

--- a/src/tools/workflow/get-attempt-logs.ts
+++ b/src/tools/workflow/get-attempt-logs.ts
@@ -1,0 +1,73 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+import type { LogLevel } from '../../types/workflow.js';
+
+export const getAttemptLogs = {
+  name: 'get_attempt_logs',
+  description: 'Retrieve aggregated logs for an entire attempt',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      attempt_id: {
+        type: 'string',
+        description: 'Attempt ID',
+      },
+      task_filter: {
+        type: 'string',
+        description: 'Filter by task name pattern',
+      },
+      level_filter: {
+        type: 'string',
+        enum: ['ERROR', 'WARN', 'INFO', 'DEBUG'],
+        description: 'Filter by log level',
+      },
+      offset: {
+        type: 'number',
+        description: 'Byte offset for pagination',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum bytes to return (default: 1MB)',
+      },
+    },
+    required: ['attempt_id'],
+  },
+  handler: async (args: unknown) => {
+    const { attempt_id, task_filter, level_filter, offset, limit = 1048576 } = args as {
+      attempt_id: string;
+      task_filter?: string;
+      level_filter?: LogLevel;
+      offset?: number;
+      limit?: number;
+    };
+
+    if (!attempt_id) {
+      throw new Error('attempt_id is required');
+    }
+
+    const config = loadConfig();
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.getAttemptLogs({
+        attempt_id,
+        task_filter,
+        level_filter,
+        offset,
+        limit,
+      });
+
+      return {
+        logs: response.logs,
+        next_offset: response.next_offset,
+        has_more: response.has_more,
+        count: response.logs.length,
+      };
+    } catch (error) {
+      throw new Error(`Failed to get attempt logs: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/get-attempt-tasks.ts
+++ b/src/tools/workflow/get-attempt-tasks.ts
@@ -1,0 +1,53 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+
+export const getAttemptTasks = {
+  name: 'get_attempt_tasks',
+  description: 'List all tasks within an attempt with their execution status',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      attempt_id: {
+        type: 'string',
+        description: 'Attempt ID',
+      },
+      include_subtasks: {
+        type: 'boolean',
+        description: 'Include subtasks (default: true)',
+      },
+    },
+    required: ['attempt_id'],
+  },
+  handler: async (args: unknown) => {
+    const { attempt_id, include_subtasks = true } = args as {
+      attempt_id: string;
+      include_subtasks?: boolean;
+    };
+
+    if (!attempt_id) {
+      throw new Error('attempt_id is required');
+    }
+
+    const config = loadConfig();
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.getAttemptTasks(attempt_id, include_subtasks);
+
+      // Filter to show failed tasks first for easier debugging
+      const failedTasks = response.tasks.filter(t => t.state === 'error');
+      const otherTasks = response.tasks.filter(t => t.state !== 'error');
+
+      return {
+        tasks: [...failedTasks, ...otherTasks],
+        count: response.tasks.length,
+        failed_count: failedTasks.length,
+      };
+    } catch (error) {
+      throw new Error(`Failed to get attempt tasks: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/get-session-attempts.ts
+++ b/src/tools/workflow/get-session-attempts.ts
@@ -1,0 +1,43 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+
+export const getSessionAttempts = {
+  name: 'get_session_attempts',
+  description: 'Get detailed information about all attempts for a specific session',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      session_id: {
+        type: 'string',
+        description: 'Session ID',
+      },
+    },
+    required: ['session_id'],
+  },
+  handler: async (args: unknown) => {
+    const { session_id } = args as {
+      session_id: string;
+    };
+
+    if (!session_id) {
+      throw new Error('session_id is required');
+    }
+
+    const config = loadConfig();
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.getSessionAttempts(session_id);
+
+      return {
+        attempts: response.attempts,
+        count: response.attempts.length,
+      };
+    } catch (error) {
+      throw new Error(`Failed to get session attempts: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/get-task-logs.ts
+++ b/src/tools/workflow/get-task-logs.ts
@@ -1,0 +1,68 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+
+export const getTaskLogs = {
+  name: 'get_task_logs',
+  description: 'Retrieve logs for a specific task',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      attempt_id: {
+        type: 'string',
+        description: 'Attempt ID',
+      },
+      task_name: {
+        type: 'string',
+        description: 'Full task name (e.g., "+main+extract_data")',
+      },
+      offset: {
+        type: 'number',
+        description: 'Byte offset for pagination',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum bytes to return (default: 1MB)',
+      },
+    },
+    required: ['attempt_id', 'task_name'],
+  },
+  handler: async (args: unknown) => {
+    const { attempt_id, task_name, offset, limit = 1048576 } = args as {
+      attempt_id: string;
+      task_name: string;
+      offset?: number;
+      limit?: number;
+    };
+
+    if (!attempt_id) {
+      throw new Error('attempt_id is required');
+    }
+
+    if (!task_name) {
+      throw new Error('task_name is required');
+    }
+
+    const config = loadConfig();
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.getTaskLogs({
+        attempt_id,
+        task_name,
+        offset,
+        limit,
+      });
+
+      return {
+        logs: response.logs,
+        next_offset: response.next_offset,
+        has_more: response.has_more,
+      };
+    } catch (error) {
+      throw new Error(`Failed to get task logs: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/index.ts
+++ b/src/tools/workflow/index.ts
@@ -1,0 +1,9 @@
+export { listWorkflows } from './list-workflows.js';
+export { listSessions } from './list-sessions.js';
+export { getSessionAttempts } from './get-session-attempts.js';
+export { getAttemptTasks } from './get-attempt-tasks.js';
+export { getTaskLogs } from './get-task-logs.js';
+export { getAttemptLogs } from './get-attempt-logs.js';
+export { killAttempt } from './kill-attempt.js';
+export { retrySession } from './retry-session.js';
+export { retryAttempt } from './retry-attempt.js';

--- a/src/tools/workflow/kill-attempt.ts
+++ b/src/tools/workflow/kill-attempt.ts
@@ -1,0 +1,56 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+
+export const killAttempt = {
+  name: 'kill_attempt',
+  description: 'Request cancellation of a running attempt',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      attempt_id: {
+        type: 'string',
+        description: 'Attempt ID',
+      },
+      reason: {
+        type: 'string',
+        description: 'Reason for cancellation',
+      },
+    },
+    required: ['attempt_id'],
+  },
+  handler: async (args: unknown) => {
+    const { attempt_id, reason } = args as {
+      attempt_id: string;
+      reason?: string;
+    };
+
+    if (!attempt_id) {
+      throw new Error('attempt_id is required');
+    }
+
+    const config = loadConfig();
+    
+    // Check if updates are enabled for workflow control operations
+    if (!config.enable_updates) {
+      throw new Error(
+        'Workflow control operations are disabled. Set TD_ENABLE_UPDATES=true to enable.'
+      );
+    }
+
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.killAttempt(attempt_id, reason);
+
+      return {
+        success: response.success,
+        message: response.message,
+      };
+    } catch (error) {
+      throw new Error(`Failed to kill attempt: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/list-sessions.ts
+++ b/src/tools/workflow/list-sessions.ts
@@ -1,0 +1,88 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+import type { WorkflowStatus } from '../../types/workflow.js';
+
+export const listSessions = {
+  name: 'list_sessions',
+  description: 'List workflow execution sessions with filtering options',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      project_name: {
+        type: 'string',
+        description: 'Filter by project name',
+      },
+      workflow_name: {
+        type: 'string',
+        description: 'Filter by workflow name',
+      },
+      status: {
+        type: 'string',
+        enum: ['running', 'success', 'error', 'killed', 'planned'],
+        description: 'Filter by status',
+      },
+      from_time: {
+        type: 'string',
+        description: 'Start time (ISO 8601)',
+      },
+      to_time: {
+        type: 'string',
+        description: 'End time (ISO 8601)',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum results (default: 100)',
+      },
+      last_id: {
+        type: 'string',
+        description: 'Pagination cursor',
+      },
+    },
+    required: [],
+  },
+  handler: async (args: unknown) => {
+    const {
+      project_name,
+      workflow_name,
+      status,
+      from_time,
+      to_time,
+      limit = 100,
+      last_id,
+    } = args as {
+      project_name?: string;
+      workflow_name?: string;
+      status?: WorkflowStatus;
+      from_time?: string;
+      to_time?: string;
+      limit?: number;
+      last_id?: string;
+    };
+
+    const config = loadConfig();
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.listSessions({
+        project_name,
+        workflow_name,
+        status,
+        from_time,
+        to_time,
+        limit,
+        last_id,
+      });
+
+      return {
+        sessions: response.sessions,
+        next_page_id: response.next_page_id,
+        count: response.sessions.length,
+      };
+    } catch (error) {
+      throw new Error(`Failed to list sessions: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/list-workflows.ts
+++ b/src/tools/workflow/list-workflows.ts
@@ -1,0 +1,58 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+
+export const listWorkflows = {
+  name: 'list_workflows',
+  description: 'List all workflows in a project with their current status',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      project_name: {
+        type: 'string',
+        description: 'Name of the project',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of workflows to return (default: 100)',
+      },
+      last_id: {
+        type: 'string',
+        description: 'Pagination cursor for next page',
+      },
+    },
+    required: ['project_name'],
+  },
+  handler: async (args: unknown) => {
+    const { project_name, limit = 100, last_id } = args as {
+      project_name: string;
+      limit?: number;
+      last_id?: string;
+    };
+
+    if (!project_name) {
+      throw new Error('project_name is required');
+    }
+
+    const config = loadConfig();
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.listWorkflows({
+        project_name,
+        limit,
+        last_id,
+      });
+
+      return {
+        workflows: response.workflows,
+        next_page_id: response.next_page_id,
+        count: response.workflows.length,
+      };
+    } catch (error) {
+      throw new Error(`Failed to list workflows: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/retry-attempt.ts
+++ b/src/tools/workflow/retry-attempt.ts
@@ -1,0 +1,73 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+
+export const retryAttempt = {
+  name: 'retry_attempt',
+  description: 'Retry a specific failed attempt with resume capabilities',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      attempt_id: {
+        type: 'string',
+        description: 'Attempt ID to retry',
+      },
+      resume_from: {
+        type: 'string',
+        description: 'Task name to resume from (skip successful tasks)',
+      },
+      retry_params: {
+        type: 'object',
+        description: 'Override parameters for retry',
+      },
+      force: {
+        type: 'boolean',
+        description: 'Force retry even if attempt is running (default: false)',
+      },
+    },
+    required: ['attempt_id'],
+  },
+  handler: async (args: unknown) => {
+    const { attempt_id, resume_from, retry_params, force = false } = args as {
+      attempt_id: string;
+      resume_from?: string;
+      retry_params?: Record<string, unknown>;
+      force?: boolean;
+    };
+
+    if (!attempt_id) {
+      throw new Error('attempt_id is required');
+    }
+
+    const config = loadConfig();
+    
+    // Check if updates are enabled for workflow control operations
+    if (!config.enable_updates) {
+      throw new Error(
+        'Workflow control operations are disabled. Set TD_ENABLE_UPDATES=true to enable.'
+      );
+    }
+
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.retryAttempt({
+        attempt_id,
+        resume_from,
+        retry_params,
+        force,
+      });
+
+      return {
+        new_attempt_id: response.new_attempt_id,
+        session_id: response.session_id,
+        message: response.message,
+        resumed_from: response.resumed_from,
+      };
+    } catch (error) {
+      throw new Error(`Failed to retry attempt: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/tools/workflow/retry-session.ts
+++ b/src/tools/workflow/retry-session.ts
@@ -1,0 +1,65 @@
+import { loadConfig } from '../../config.js';
+import { WorkflowClient } from '../../client/workflow/index.js';
+
+export const retrySession = {
+  name: 'retry_session',
+  description: 'Retry a failed session from the beginning or a specific task',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      session_id: {
+        type: 'string',
+        description: 'Session ID',
+      },
+      from_task: {
+        type: 'string',
+        description: 'Task name to retry from',
+      },
+      retry_params: {
+        type: 'object',
+        description: 'Override parameters for retry',
+      },
+    },
+    required: ['session_id'],
+  },
+  handler: async (args: unknown) => {
+    const { session_id, from_task, retry_params } = args as {
+      session_id: string;
+      from_task?: string;
+      retry_params?: Record<string, unknown>;
+    };
+
+    if (!session_id) {
+      throw new Error('session_id is required');
+    }
+
+    const config = loadConfig();
+    
+    // Check if updates are enabled for workflow control operations
+    if (!config.enable_updates) {
+      throw new Error(
+        'Workflow control operations are disabled. Set TD_ENABLE_UPDATES=true to enable.'
+      );
+    }
+
+    const client = new WorkflowClient({
+      apiKey: config.td_api_key,
+      site: config.site,
+    });
+
+    try {
+      const response = await client.retrySession({
+        session_id,
+        from_task,
+        retry_params,
+      });
+
+      return {
+        attempt_id: response.attempt_id,
+        message: response.message,
+      };
+    } catch (error) {
+      throw new Error(`Failed to retry session: ${(error as Error).message || String(error)}`);
+    }
+  },
+};

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -1,0 +1,130 @@
+// Workflow-related types
+
+export type WorkflowStatus = 'running' | 'success' | 'error' | 'killed' | 'planned';
+export type TaskState = 'running' | 'success' | 'error' | 'blocked' | 'ready' | 'retry_waiting' | 'group_retry_waiting' | 'planned' | 'canceled';
+export type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG';
+
+export interface Workflow {
+  id: string;
+  name: string;
+  project: string;
+  revision: string;
+  timezone: string;
+  last_session_time?: string;
+  last_session_status?: WorkflowStatus;
+}
+
+export interface WorkflowListResponse {
+  workflows: Workflow[];
+  next_page_id?: string;
+}
+
+export interface SessionAttempt {
+  id: string;
+  status: WorkflowStatus;
+  done: boolean;
+  success: boolean;
+  cancel_requested: boolean;
+  created_at: string;
+  finished_at?: string;
+}
+
+export interface Session {
+  id: string;
+  project: string;
+  workflow: string;
+  session_uuid: string;
+  session_time: string;
+  finish_time?: string;
+  status: WorkflowStatus;
+  params: Record<string, unknown>;
+  attempt?: SessionAttempt;
+}
+
+export interface SessionListResponse {
+  sessions: Session[];
+  next_page_id?: string;
+}
+
+export interface Attempt {
+  id: string;
+  index: number;
+  status: WorkflowStatus;
+  state_params: Record<string, unknown>;
+  done: boolean;
+  success: boolean;
+  cancel_requested: boolean;
+  created_at: string;
+  finished_at?: string;
+  retry_attempt_name?: string;
+}
+
+export interface AttemptsResponse {
+  attempts: Attempt[];
+}
+
+export interface TaskError {
+  message: string;
+  type: string;
+  stack_trace?: string;
+}
+
+export interface Task {
+  id: string;
+  full_name: string;
+  parent_id?: string;
+  config: Record<string, unknown>;
+  upstream_ids: string[];
+  state: TaskState;
+  export_params: Record<string, unknown>;
+  store_params: Record<string, unknown>;
+  state_params: Record<string, unknown>;
+  updated_at: string;
+  retry_at?: string;
+  started_at?: string;
+  error?: TaskError;
+}
+
+export interface TasksResponse {
+  tasks: Task[];
+}
+
+export interface LogsResponse {
+  logs: string;
+  next_offset?: number;
+  has_more: boolean;
+}
+
+export interface LogEntry {
+  task: string;
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  context: {
+    attempt_id: string;
+    session_id: string;
+  };
+}
+
+export interface AttemptLogsResponse {
+  logs: LogEntry[];
+  next_offset?: number;
+  has_more: boolean;
+}
+
+export interface KillAttemptResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface RetrySessionResponse {
+  attempt_id: string;
+  message: string;
+}
+
+export interface RetryAttemptResponse {
+  new_attempt_id: string;
+  session_id: string;
+  message: string;
+  resumed_from?: string;
+}

--- a/tests/client/workflow/client.test.ts
+++ b/tests/client/workflow/client.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { WorkflowClient } from '../../../src/client/workflow/client';
+import { maskApiKey } from '../../../src/config';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+// Mock config module
+vi.mock('../../../src/config', () => ({
+  maskApiKey: vi.fn((key: string) => `${key.substring(0, 4)}...${key.substring(key.length - 4)}`),
+}));
+
+describe('WorkflowClient', () => {
+  let client: WorkflowClient;
+  const mockApiKey = 'test_api_key_123456';
+  const mockFetch = global.fetch as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new WorkflowClient({
+      apiKey: mockApiKey,
+      site: 'us01',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with correct settings', () => {
+      const customClient = new WorkflowClient({
+        apiKey: 'key123',
+        site: 'jp01',
+        timeout: 60000,
+      });
+      expect(customClient).toBeDefined();
+    });
+
+    it('should use default timeout when not specified', () => {
+      const defaultClient = new WorkflowClient({
+        apiKey: 'key123',
+        site: 'us01',
+      });
+      expect(defaultClient).toBeDefined();
+    });
+  });
+
+  describe('listWorkflows', () => {
+    it('should fetch workflows successfully', async () => {
+      const mockResponse = {
+        workflows: [
+          { id: '1', name: 'workflow1', project: 'test', revision: 'abc', timezone: 'UTC' },
+          { id: '2', name: 'workflow2', project: 'test', revision: 'def', timezone: 'UTC' },
+        ],
+        next_page_id: 'next123',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.listWorkflows({
+        project_name: 'test',
+        limit: 10,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api-workflow.treasuredata.com/api/projects/test/workflows?page_size=10',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            'Authorization': `TD1 ${mockApiKey}`,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+          }),
+        })
+      );
+    });
+
+    it('should handle pagination parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ workflows: [], next_page_id: null }),
+      });
+
+      await client.listWorkflows({
+        project_name: 'test',
+        limit: 50,
+        last_id: 'last123',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('page_size=50&last_id=last123'),
+        expect.any(Object)
+      );
+    });
+
+    it('should handle API errors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => 'Project not found',
+      });
+
+      await expect(client.listWorkflows({ project_name: 'nonexistent' }))
+        .rejects.toThrow('Workflow API error (404): Project not found');
+    });
+  });
+
+  describe('listSessions', () => {
+    it('should list all sessions without filters', async () => {
+      const mockResponse = {
+        sessions: [
+          {
+            id: '1',
+            project: 'test',
+            workflow: 'wf1',
+            session_uuid: 'uuid1',
+            session_time: '2024-01-01T00:00:00Z',
+            status: 'success' as const,
+            params: {},
+          },
+        ],
+        next_page_id: null,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.listSessions({});
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api-workflow.treasuredata.com/api/sessions',
+        expect.any(Object)
+      );
+    });
+
+    it('should list sessions for specific workflow', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sessions: [], next_page_id: null }),
+      });
+
+      await client.listSessions({
+        project_name: 'test',
+        workflow_name: 'workflow1',
+        status: 'error',
+        from_time: '2024-01-01T00:00:00Z',
+        to_time: '2024-01-02T00:00:00Z',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/projects/test/workflows/workflow1/sessions'),
+        expect.any(Object)
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('status=error'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('getSessionAttempts', () => {
+    it('should get attempts for a session', async () => {
+      const mockResponse = {
+        attempts: [
+          {
+            id: '1',
+            index: 1,
+            status: 'error' as const,
+            state_params: {},
+            done: true,
+            success: false,
+            cancel_requested: false,
+            created_at: '2024-01-01T00:00:00Z',
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.getSessionAttempts('session123');
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api-workflow.treasuredata.com/api/sessions/session123/attempts',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('getAttemptTasks', () => {
+    it('should get tasks with subtasks by default', async () => {
+      const mockResponse = {
+        tasks: [
+          {
+            id: '1',
+            full_name: '+main+task1',
+            state: 'success' as const,
+            config: {},
+            upstream_ids: [],
+            export_params: {},
+            store_params: {},
+            state_params: {},
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.getAttemptTasks('attempt123');
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include_subtasks=true'),
+        expect.any(Object)
+      );
+    });
+
+    it('should exclude subtasks when requested', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tasks: [] }),
+      });
+
+      await client.getAttemptTasks('attempt123', false);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include_subtasks=false'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('getTaskLogs', () => {
+    it('should get logs for a specific task', async () => {
+      const mockResponse = {
+        logs: '2024-01-01 00:00:00 [INFO] Task started',
+        next_offset: 1024,
+        has_more: true,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.getTaskLogs({
+        attempt_id: 'attempt123',
+        task_name: '+main+task1',
+        offset: 0,
+        limit: 1000,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/attempts/attempt123/tasks/%2Bmain%2Btask1/logs'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('getAttemptLogs', () => {
+    it('should get aggregated logs with filters', async () => {
+      const mockResponse = {
+        logs: [
+          {
+            task: '+main+task1',
+            timestamp: '2024-01-01T00:00:00Z',
+            level: 'ERROR' as const,
+            message: 'Task failed',
+            context: { attempt_id: 'attempt123', session_id: 'session123' },
+          },
+        ],
+        next_offset: 2048,
+        has_more: false,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.getAttemptLogs({
+        attempt_id: 'attempt123',
+        task_filter: 'main',
+        level_filter: 'ERROR',
+        limit: 5000,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('task_filter=main&level_filter=ERROR'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('killAttempt', () => {
+    it('should kill an attempt with reason', async () => {
+      const mockResponse = {
+        success: true,
+        message: 'Cancellation requested',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.killAttempt('attempt123', 'User requested');
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api-workflow.treasuredata.com/api/attempts/attempt123/kill',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ reason: 'User requested' }),
+        })
+      );
+    });
+  });
+
+  describe('retrySession', () => {
+    it('should retry a session from specific task', async () => {
+      const mockResponse = {
+        attempt_id: 'new_attempt123',
+        message: 'Retry attempt created',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.retrySession({
+        session_id: 'session123',
+        from_task: '+main+task2',
+        retry_params: { override: 'value' },
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api-workflow.treasuredata.com/api/sessions/session123/retry',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            from_task: '+main+task2',
+            params: { override: 'value' },
+          }),
+        })
+      );
+    });
+  });
+
+  describe('retryAttempt', () => {
+    it('should retry an attempt with resume', async () => {
+      const mockResponse = {
+        new_attempt_id: 'new_attempt123',
+        session_id: 'session123',
+        message: 'Retry attempt created',
+        resumed_from: '+main+task3',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await client.retryAttempt({
+        attempt_id: 'attempt123',
+        resume_from: '+main+task3',
+        retry_params: { param: 'value' },
+        force: true,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api-workflow.treasuredata.com/api/attempts/attempt123/retry',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            resume_from: '+main+task3',
+            params: { param: 'value' },
+            force: true,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should mask API key in error messages', async () => {
+      const errorMessage = `Connection failed with key ${mockApiKey}`;
+      mockFetch.mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(client.listWorkflows({ project_name: 'test' }))
+        .rejects.toThrow('Connection failed with key test...3456');
+
+      expect(maskApiKey).toHaveBeenCalledWith(mockApiKey);
+    });
+
+    it('should handle network timeout', async () => {
+      // Mock AbortController behavior
+      let abortSignal: AbortSignal | undefined;
+      mockFetch.mockImplementationOnce((url: string, options: any) => {
+        abortSignal = options.signal;
+        // Simulate network delay longer than timeout
+        return new Promise((resolve, reject) => {
+          const timeoutId = setTimeout(() => {
+            resolve({
+              ok: true,
+              json: async () => ({ workflows: [] }),
+            });
+          }, 200);
+
+          // Listen for abort signal
+          if (abortSignal) {
+            abortSignal.addEventListener('abort', () => {
+              clearTimeout(timeoutId);
+              reject(new Error('The operation was aborted'));
+            });
+          }
+        });
+      });
+
+      const fastClient = new WorkflowClient({
+        apiKey: mockApiKey,
+        site: 'us01',
+        timeout: 50, // 50ms timeout (shorter than mock delay)
+      });
+
+      await expect(fastClient.listWorkflows({ project_name: 'test' }))
+        .rejects.toThrow('The operation was aborted');
+    });
+
+    it('should handle non-JSON error responses', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => { throw new Error('Not JSON'); },
+      });
+
+      await expect(client.listWorkflows({ project_name: 'test' }))
+        .rejects.toThrow('Workflow API error (500): Unknown error');
+    });
+  });
+});

--- a/tests/client/workflow/endpoints.test.ts
+++ b/tests/client/workflow/endpoints.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { getWorkflowEndpoint, transformToWorkflowEndpoint, WORKFLOW_ENDPOINTS } from '../../../src/client/workflow/endpoints';
+
+describe('Workflow Endpoints', () => {
+  describe('WORKFLOW_ENDPOINTS', () => {
+    it('should have all supported sites', () => {
+      expect(WORKFLOW_ENDPOINTS).toHaveProperty('us01');
+      expect(WORKFLOW_ENDPOINTS).toHaveProperty('jp01');
+      expect(WORKFLOW_ENDPOINTS).toHaveProperty('eu01');
+      expect(WORKFLOW_ENDPOINTS).toHaveProperty('ap02');
+      expect(WORKFLOW_ENDPOINTS).toHaveProperty('ap03');
+      expect(WORKFLOW_ENDPOINTS).toHaveProperty('dev');
+    });
+
+    it('should have correct endpoint URLs', () => {
+      expect(WORKFLOW_ENDPOINTS.us01).toBe('https://api-workflow.treasuredata.com');
+      expect(WORKFLOW_ENDPOINTS.jp01).toBe('https://api-workflow.treasuredata.co.jp');
+      expect(WORKFLOW_ENDPOINTS.eu01).toBe('https://api-workflow.eu01.treasuredata.com');
+      expect(WORKFLOW_ENDPOINTS.ap02).toBe('https://api-workflow.ap02.treasuredata.com');
+      expect(WORKFLOW_ENDPOINTS.ap03).toBe('https://api-workflow.ap03.treasuredata.com');
+      expect(WORKFLOW_ENDPOINTS.dev).toBe('https://api-development-workflow.connect.treasuredata.com');
+    });
+  });
+
+  describe('getWorkflowEndpoint', () => {
+    it('should return correct endpoint for valid sites', () => {
+      expect(getWorkflowEndpoint('us01')).toBe('https://api-workflow.treasuredata.com');
+      expect(getWorkflowEndpoint('jp01')).toBe('https://api-workflow.treasuredata.co.jp');
+      expect(getWorkflowEndpoint('eu01')).toBe('https://api-workflow.eu01.treasuredata.com');
+      expect(getWorkflowEndpoint('dev')).toBe('https://api-development-workflow.connect.treasuredata.com');
+    });
+
+    it('should throw error for unsupported site', () => {
+      expect(() => getWorkflowEndpoint('invalid' as any)).toThrow('Unsupported TD site: invalid');
+    });
+  });
+
+  describe('transformToWorkflowEndpoint', () => {
+    it('should transform production endpoints correctly', () => {
+      expect(transformToWorkflowEndpoint('api.treasuredata.com'))
+        .toBe('https://api-workflow.treasuredata.com');
+      
+      expect(transformToWorkflowEndpoint('api.treasuredata.co.jp'))
+        .toBe('https://api-workflow.treasuredata.co.jp');
+      
+      expect(transformToWorkflowEndpoint('api.eu01.treasuredata.com'))
+        .toBe('https://api-workflow.eu01.treasuredata.com');
+      
+      expect(transformToWorkflowEndpoint('api.ap02.treasuredata.com'))
+        .toBe('https://api-workflow.ap02.treasuredata.com');
+      
+      expect(transformToWorkflowEndpoint('api.ap03.treasuredata.com'))
+        .toBe('https://api-workflow.ap03.treasuredata.com');
+    });
+
+    it('should transform development endpoints correctly', () => {
+      expect(transformToWorkflowEndpoint('api-development.connect.treasuredata.com'))
+        .toBe('https://api-development-workflow.connect.treasuredata.com');
+      
+      expect(transformToWorkflowEndpoint('api-staging.connect.treasuredata.com'))
+        .toBe('https://api-staging-workflow.connect.treasuredata.com');
+    });
+
+    it('should transform endpoints with suffixes correctly', () => {
+      expect(transformToWorkflowEndpoint('api-development-test.connect.treasuredata.com'))
+        .toBe('https://api-development-workflow-test.connect.treasuredata.com');
+      
+      expect(transformToWorkflowEndpoint('api-staging-feature.connect.treasuredata.com'))
+        .toBe('https://api-staging-workflow-feature.connect.treasuredata.com');
+    });
+
+    it('should handle case insensitive matching', () => {
+      expect(transformToWorkflowEndpoint('API.TreasureData.COM'))
+        .toBe('https://api-workflow.treasuredata.com');
+    });
+
+    it('should throw error for invalid endpoint format', () => {
+      expect(() => transformToWorkflowEndpoint('invalid.endpoint.com'))
+        .toThrow('Invalid API endpoint format: invalid.endpoint.com');
+      
+      expect(() => transformToWorkflowEndpoint('https://api.treasuredata.com'))
+        .toThrow('Invalid API endpoint format: https://api.treasuredata.com');
+      
+      expect(() => transformToWorkflowEndpoint('api.treasuredata'))
+        .toThrow('Invalid API endpoint format: api.treasuredata');
+    });
+  });
+});

--- a/tests/tools/workflow/get-attempt-tasks.test.ts
+++ b/tests/tools/workflow/get-attempt-tasks.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getAttemptTasks } from '../../../src/tools/workflow/get-attempt-tasks';
+import { loadConfig } from '../../../src/config';
+import { WorkflowClient } from '../../../src/client/workflow';
+
+vi.mock('../../../src/config');
+vi.mock('../../../src/client/workflow');
+
+describe('getAttemptTasks tool', () => {
+  const mockLoadConfig = loadConfig as any;
+  const MockWorkflowClient = WorkflowClient as any;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    mockLoadConfig.mockReturnValue({
+      td_api_key: 'test_key',
+      site: 'us01',
+    });
+
+    mockClient = {
+      getAttemptTasks: vi.fn(),
+    };
+
+    MockWorkflowClient.mockImplementation(() => mockClient);
+  });
+
+  describe('metadata', () => {
+    it('should have correct tool metadata', () => {
+      expect(getAttemptTasks.name).toBe('get_attempt_tasks');
+      expect(getAttemptTasks.description).toBe('List all tasks within an attempt with their execution status');
+      expect(getAttemptTasks.inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          attempt_id: {
+            type: 'string',
+            description: 'Attempt ID',
+          },
+          include_subtasks: {
+            type: 'boolean',
+            description: 'Include subtasks (default: true)',
+          },
+        },
+        required: ['attempt_id'],
+      });
+    });
+  });
+
+  describe('handler', () => {
+    it('should get tasks and prioritize failed tasks', async () => {
+      const mockResponse = {
+        tasks: [
+          {
+            id: '1',
+            full_name: '+main+task1',
+            state: 'success',
+            config: {},
+            upstream_ids: [],
+            export_params: {},
+            store_params: {},
+            state_params: {},
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+          {
+            id: '2',
+            full_name: '+main+task2',
+            state: 'error',
+            config: {},
+            upstream_ids: ['1'],
+            export_params: {},
+            store_params: {},
+            state_params: {},
+            updated_at: '2024-01-01T00:01:00Z',
+            error: {
+              message: 'Connection timeout',
+              type: 'NetworkError',
+            },
+          },
+          {
+            id: '3',
+            full_name: '+main+task3',
+            state: 'success',
+            config: {},
+            upstream_ids: ['1'],
+            export_params: {},
+            store_params: {},
+            state_params: {},
+            updated_at: '2024-01-01T00:02:00Z',
+          },
+          {
+            id: '4',
+            full_name: '+main+task4',
+            state: 'error',
+            config: {},
+            upstream_ids: ['3'],
+            export_params: {},
+            store_params: {},
+            state_params: {},
+            updated_at: '2024-01-01T00:03:00Z',
+            error: {
+              message: 'Invalid input',
+              type: 'ValidationError',
+            },
+          },
+        ],
+      };
+
+      mockClient.getAttemptTasks.mockResolvedValue(mockResponse);
+
+      const result = await getAttemptTasks.handler({
+        attempt_id: 'attempt123',
+      });
+
+      // Verify failed tasks come first
+      expect(result.tasks[0].state).toBe('error');
+      expect(result.tasks[1].state).toBe('error');
+      expect(result.tasks[2].state).toBe('success');
+      expect(result.tasks[3].state).toBe('success');
+
+      expect(result).toEqual({
+        tasks: [
+          mockResponse.tasks[1], // error task
+          mockResponse.tasks[3], // error task
+          mockResponse.tasks[0], // success task
+          mockResponse.tasks[2], // success task
+        ],
+        count: 4,
+        failed_count: 2,
+      });
+
+      expect(mockClient.getAttemptTasks).toHaveBeenCalledWith('attempt123', true);
+    });
+
+    it('should handle include_subtasks parameter', async () => {
+      mockClient.getAttemptTasks.mockResolvedValue({ tasks: [] });
+
+      await getAttemptTasks.handler({
+        attempt_id: 'attempt123',
+        include_subtasks: false,
+      });
+
+      expect(mockClient.getAttemptTasks).toHaveBeenCalledWith('attempt123', false);
+    });
+
+    it('should handle attempts with no failed tasks', async () => {
+      const mockResponse = {
+        tasks: [
+          {
+            id: '1',
+            full_name: '+main+task1',
+            state: 'success',
+            config: {},
+            upstream_ids: [],
+            export_params: {},
+            store_params: {},
+            state_params: {},
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+          {
+            id: '2',
+            full_name: '+main+task2',
+            state: 'success',
+            config: {},
+            upstream_ids: ['1'],
+            export_params: {},
+            store_params: {},
+            state_params: {},
+            updated_at: '2024-01-01T00:01:00Z',
+          },
+        ],
+      };
+
+      mockClient.getAttemptTasks.mockResolvedValue(mockResponse);
+
+      const result = await getAttemptTasks.handler({
+        attempt_id: 'attempt123',
+      });
+
+      expect(result).toEqual({
+        tasks: mockResponse.tasks,
+        count: 2,
+        failed_count: 0,
+      });
+    });
+
+    it('should handle empty task list', async () => {
+      mockClient.getAttemptTasks.mockResolvedValue({ tasks: [] });
+
+      const result = await getAttemptTasks.handler({
+        attempt_id: 'attempt123',
+      });
+
+      expect(result).toEqual({
+        tasks: [],
+        count: 0,
+        failed_count: 0,
+      });
+    });
+
+    it('should throw error when attempt_id is missing', async () => {
+      await expect(getAttemptTasks.handler({}))
+        .rejects.toThrow('attempt_id is required');
+
+      expect(mockClient.getAttemptTasks).not.toHaveBeenCalled();
+    });
+
+    it('should handle client errors gracefully', async () => {
+      mockClient.getAttemptTasks.mockRejectedValue(new Error('API error'));
+
+      await expect(getAttemptTasks.handler({
+        attempt_id: 'attempt123',
+      })).rejects.toThrow('Failed to get attempt tasks: API error');
+    });
+  });
+});

--- a/tests/tools/workflow/get-task-logs.test.ts
+++ b/tests/tools/workflow/get-task-logs.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getTaskLogs } from '../../../src/tools/workflow/get-task-logs';
+import { loadConfig } from '../../../src/config';
+import { WorkflowClient } from '../../../src/client/workflow';
+
+vi.mock('../../../src/config');
+vi.mock('../../../src/client/workflow');
+
+describe('getTaskLogs tool', () => {
+  const mockLoadConfig = loadConfig as any;
+  const MockWorkflowClient = WorkflowClient as any;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    mockLoadConfig.mockReturnValue({
+      td_api_key: 'test_key',
+      site: 'us01',
+    });
+
+    mockClient = {
+      getTaskLogs: vi.fn(),
+    };
+
+    MockWorkflowClient.mockImplementation(() => mockClient);
+  });
+
+  describe('metadata', () => {
+    it('should have correct tool metadata', () => {
+      expect(getTaskLogs.name).toBe('get_task_logs');
+      expect(getTaskLogs.description).toBe('Retrieve logs for a specific task');
+      expect(getTaskLogs.inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          attempt_id: {
+            type: 'string',
+            description: 'Attempt ID',
+          },
+          task_name: {
+            type: 'string',
+            description: 'Full task name (e.g., "+main+extract_data")',
+          },
+          offset: {
+            type: 'number',
+            description: 'Byte offset for pagination',
+          },
+          limit: {
+            type: 'number',
+            description: 'Maximum bytes to return (default: 1MB)',
+          },
+        },
+        required: ['attempt_id', 'task_name'],
+      });
+    });
+  });
+
+  describe('handler', () => {
+    it('should retrieve task logs successfully', async () => {
+      const mockLogs = `2024-01-01 00:00:00 +0000 [INFO] Starting data extraction...
+2024-01-01 00:00:05 +0000 [INFO] Connected to database
+2024-01-01 00:00:10 +0000 [INFO] Extracted 1000 records
+2024-01-01 00:00:15 +0000 [ERROR] Connection timeout to remote API
+2024-01-01 00:00:16 +0000 [ERROR] Task failed`;
+
+      const mockResponse = {
+        logs: mockLogs,
+        next_offset: 2048,
+        has_more: true,
+      };
+
+      mockClient.getTaskLogs.mockResolvedValue(mockResponse);
+
+      const result = await getTaskLogs.handler({
+        attempt_id: 'attempt123',
+        task_name: '+main+extract_data',
+      });
+
+      expect(result).toEqual({
+        logs: mockLogs,
+        next_offset: 2048,
+        has_more: true,
+      });
+
+      expect(mockClient.getTaskLogs).toHaveBeenCalledWith({
+        attempt_id: 'attempt123',
+        task_name: '+main+extract_data',
+        offset: undefined,
+        limit: 1048576, // 1MB default
+      });
+    });
+
+    it('should handle pagination parameters', async () => {
+      const mockResponse = {
+        logs: 'Partial logs...',
+        next_offset: 5000,
+        has_more: true,
+      };
+
+      mockClient.getTaskLogs.mockResolvedValue(mockResponse);
+
+      await getTaskLogs.handler({
+        attempt_id: 'attempt123',
+        task_name: '+main+task',
+        offset: 2048,
+        limit: 4096,
+      });
+
+      expect(mockClient.getTaskLogs).toHaveBeenCalledWith({
+        attempt_id: 'attempt123',
+        task_name: '+main+task',
+        offset: 2048,
+        limit: 4096,
+      });
+    });
+
+    it('should handle task names with special characters', async () => {
+      const mockResponse = {
+        logs: '',
+        next_offset: undefined,
+        has_more: false,
+      };
+
+      mockClient.getTaskLogs.mockResolvedValue(mockResponse);
+
+      await getTaskLogs.handler({
+        attempt_id: 'attempt123',
+        task_name: '+main+task:with:colons+and+plus',
+      });
+
+      expect(mockClient.getTaskLogs).toHaveBeenCalledWith({
+        attempt_id: 'attempt123',
+        task_name: '+main+task:with:colons+and+plus',
+        offset: undefined,
+        limit: 1048576,
+      });
+    });
+
+    it('should handle empty logs', async () => {
+      const mockResponse = {
+        logs: '',
+        next_offset: undefined,
+        has_more: false,
+      };
+
+      mockClient.getTaskLogs.mockResolvedValue(mockResponse);
+
+      const result = await getTaskLogs.handler({
+        attempt_id: 'attempt123',
+        task_name: '+main+no_logs_task',
+      });
+
+      expect(result).toEqual({
+        logs: '',
+        next_offset: undefined,
+        has_more: false,
+      });
+    });
+
+    it('should use default limit when not specified', async () => {
+      mockClient.getTaskLogs.mockResolvedValue({
+        logs: 'logs',
+        has_more: false,
+      });
+
+      await getTaskLogs.handler({
+        attempt_id: 'attempt123',
+        task_name: '+main+task',
+      });
+
+      expect(mockClient.getTaskLogs).toHaveBeenCalledWith({
+        attempt_id: 'attempt123',
+        task_name: '+main+task',
+        offset: undefined,
+        limit: 1048576, // 1MB in bytes
+      });
+    });
+
+    it('should throw error when attempt_id is missing', async () => {
+      await expect(getTaskLogs.handler({
+        task_name: '+main+task',
+      })).rejects.toThrow('attempt_id is required');
+
+      expect(mockClient.getTaskLogs).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when task_name is missing', async () => {
+      await expect(getTaskLogs.handler({
+        attempt_id: 'attempt123',
+      })).rejects.toThrow('task_name is required');
+
+      expect(mockClient.getTaskLogs).not.toHaveBeenCalled();
+    });
+
+    it('should handle client errors gracefully', async () => {
+      mockClient.getTaskLogs.mockRejectedValue(new Error('Task not found'));
+
+      await expect(getTaskLogs.handler({
+        attempt_id: 'attempt123',
+        task_name: '+main+nonexistent',
+      })).rejects.toThrow('Failed to get task logs: Task not found');
+    });
+
+    it('should handle non-Error exceptions', async () => {
+      mockClient.getTaskLogs.mockRejectedValue('Network timeout');
+
+      await expect(getTaskLogs.handler({
+        attempt_id: 'attempt123',
+        task_name: '+main+task',
+      })).rejects.toThrow('Failed to get task logs: Network timeout');
+    });
+  });
+});

--- a/tests/tools/workflow/kill-attempt.test.ts
+++ b/tests/tools/workflow/kill-attempt.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { killAttempt } from '../../../src/tools/workflow/kill-attempt';
+import { loadConfig } from '../../../src/config';
+import { WorkflowClient } from '../../../src/client/workflow';
+
+vi.mock('../../../src/config');
+vi.mock('../../../src/client/workflow');
+
+describe('killAttempt tool', () => {
+  const mockLoadConfig = loadConfig as any;
+  const MockWorkflowClient = WorkflowClient as any;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    mockClient = {
+      killAttempt: vi.fn(),
+    };
+
+    MockWorkflowClient.mockImplementation(() => mockClient);
+  });
+
+  describe('metadata', () => {
+    it('should have correct tool metadata', () => {
+      expect(killAttempt.name).toBe('kill_attempt');
+      expect(killAttempt.description).toBe('Request cancellation of a running attempt');
+      expect(killAttempt.inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          attempt_id: {
+            type: 'string',
+            description: 'Attempt ID',
+          },
+          reason: {
+            type: 'string',
+            description: 'Reason for cancellation',
+          },
+        },
+        required: ['attempt_id'],
+      });
+    });
+  });
+
+  describe('handler', () => {
+    it('should kill attempt when updates are enabled', async () => {
+      mockLoadConfig.mockReturnValue({
+        td_api_key: 'test_key',
+        site: 'us01',
+        enable_updates: true,
+      });
+
+      const mockResponse = {
+        success: true,
+        message: 'Cancellation requested for attempt 123',
+      };
+
+      mockClient.killAttempt.mockResolvedValue(mockResponse);
+
+      const result = await killAttempt.handler({
+        attempt_id: 'attempt123',
+        reason: 'User requested cancellation',
+      });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Cancellation requested for attempt 123',
+      });
+
+      expect(mockClient.killAttempt).toHaveBeenCalledWith(
+        'attempt123',
+        'User requested cancellation'
+      );
+    });
+
+    it('should kill attempt without reason', async () => {
+      mockLoadConfig.mockReturnValue({
+        td_api_key: 'test_key',
+        site: 'us01',
+        enable_updates: true,
+      });
+
+      const mockResponse = {
+        success: true,
+        message: 'Cancellation requested',
+      };
+
+      mockClient.killAttempt.mockResolvedValue(mockResponse);
+
+      await killAttempt.handler({
+        attempt_id: 'attempt123',
+      });
+
+      expect(mockClient.killAttempt).toHaveBeenCalledWith(
+        'attempt123',
+        undefined
+      );
+    });
+
+    it('should throw error when updates are disabled', async () => {
+      mockLoadConfig.mockReturnValue({
+        td_api_key: 'test_key',
+        site: 'us01',
+        enable_updates: false,
+      });
+
+      await expect(killAttempt.handler({
+        attempt_id: 'attempt123',
+      })).rejects.toThrow(
+        'Workflow control operations are disabled. Set TD_ENABLE_UPDATES=true to enable.'
+      );
+
+      expect(mockClient.killAttempt).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when attempt_id is missing', async () => {
+      mockLoadConfig.mockReturnValue({
+        td_api_key: 'test_key',
+        site: 'us01',
+        enable_updates: true,
+      });
+
+      await expect(killAttempt.handler({}))
+        .rejects.toThrow('attempt_id is required');
+
+      expect(mockClient.killAttempt).not.toHaveBeenCalled();
+    });
+
+    it('should handle unsuccessful kill response', async () => {
+      mockLoadConfig.mockReturnValue({
+        td_api_key: 'test_key',
+        site: 'us01',
+        enable_updates: true,
+      });
+
+      const mockResponse = {
+        success: false,
+        message: 'Attempt is already completed',
+      };
+
+      mockClient.killAttempt.mockResolvedValue(mockResponse);
+
+      const result = await killAttempt.handler({
+        attempt_id: 'attempt123',
+      });
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Attempt is already completed',
+      });
+    });
+
+    it('should handle client errors gracefully', async () => {
+      mockLoadConfig.mockReturnValue({
+        td_api_key: 'test_key',
+        site: 'us01',
+        enable_updates: true,
+      });
+
+      mockClient.killAttempt.mockRejectedValue(new Error('Network error'));
+
+      await expect(killAttempt.handler({
+        attempt_id: 'attempt123',
+      })).rejects.toThrow('Failed to kill attempt: Network error');
+    });
+
+    it('should check enable_updates before creating client', async () => {
+      mockLoadConfig.mockReturnValue({
+        td_api_key: 'test_key',
+        site: 'us01',
+        enable_updates: false,
+      });
+
+      await expect(killAttempt.handler({
+        attempt_id: 'attempt123',
+      })).rejects.toThrow();
+
+      // Client should not be created when updates are disabled
+      expect(MockWorkflowClient).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/tools/workflow/list-workflows.test.ts
+++ b/tests/tools/workflow/list-workflows.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { listWorkflows } from '../../../src/tools/workflow/list-workflows';
+import { loadConfig } from '../../../src/config';
+import { WorkflowClient } from '../../../src/client/workflow';
+
+vi.mock('../../../src/config');
+vi.mock('../../../src/client/workflow');
+
+describe('listWorkflows tool', () => {
+  const mockLoadConfig = loadConfig as any;
+  const MockWorkflowClient = WorkflowClient as any;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    mockLoadConfig.mockReturnValue({
+      td_api_key: 'test_key',
+      site: 'us01',
+    });
+
+    mockClient = {
+      listWorkflows: vi.fn(),
+    };
+
+    MockWorkflowClient.mockImplementation(() => mockClient);
+  });
+
+  describe('metadata', () => {
+    it('should have correct tool metadata', () => {
+      expect(listWorkflows.name).toBe('list_workflows');
+      expect(listWorkflows.description).toBe('List all workflows in a project with their current status');
+      expect(listWorkflows.inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          project_name: {
+            type: 'string',
+            description: 'Name of the project',
+          },
+          limit: {
+            type: 'number',
+            description: 'Maximum number of workflows to return (default: 100)',
+          },
+          last_id: {
+            type: 'string',
+            description: 'Pagination cursor for next page',
+          },
+        },
+        required: ['project_name'],
+      });
+    });
+  });
+
+  describe('handler', () => {
+    it('should list workflows successfully', async () => {
+      const mockResponse = {
+        workflows: [
+          {
+            id: '1',
+            name: 'daily_etl',
+            project: 'test_project',
+            revision: 'abc123',
+            timezone: 'UTC',
+            last_session_time: '2024-01-01T00:00:00Z',
+            last_session_status: 'success',
+          },
+          {
+            id: '2',
+            name: 'hourly_sync',
+            project: 'test_project',
+            revision: 'def456',
+            timezone: 'UTC',
+            last_session_time: '2024-01-01T01:00:00Z',
+            last_session_status: 'error',
+          },
+        ],
+        next_page_id: 'next123',
+      };
+
+      mockClient.listWorkflows.mockResolvedValue(mockResponse);
+
+      const result = await listWorkflows.handler({
+        project_name: 'test_project',
+        limit: 50,
+      });
+
+      expect(result).toEqual({
+        workflows: mockResponse.workflows,
+        next_page_id: 'next123',
+        count: 2,
+      });
+
+      expect(mockClient.listWorkflows).toHaveBeenCalledWith({
+        project_name: 'test_project',
+        limit: 50,
+        last_id: undefined,
+      });
+    });
+
+    it('should use default limit when not specified', async () => {
+      mockClient.listWorkflows.mockResolvedValue({
+        workflows: [],
+        next_page_id: null,
+      });
+
+      await listWorkflows.handler({
+        project_name: 'test_project',
+      });
+
+      expect(mockClient.listWorkflows).toHaveBeenCalledWith({
+        project_name: 'test_project',
+        limit: 100,
+        last_id: undefined,
+      });
+    });
+
+    it('should handle pagination with last_id', async () => {
+      mockClient.listWorkflows.mockResolvedValue({
+        workflows: [],
+        next_page_id: null,
+      });
+
+      await listWorkflows.handler({
+        project_name: 'test_project',
+        last_id: 'prev123',
+      });
+
+      expect(mockClient.listWorkflows).toHaveBeenCalledWith({
+        project_name: 'test_project',
+        limit: 100,
+        last_id: 'prev123',
+      });
+    });
+
+    it('should throw error when project_name is missing', async () => {
+      await expect(listWorkflows.handler({}))
+        .rejects.toThrow('project_name is required');
+
+      expect(mockClient.listWorkflows).not.toHaveBeenCalled();
+    });
+
+    it('should handle client errors gracefully', async () => {
+      mockClient.listWorkflows.mockRejectedValue(new Error('API error'));
+
+      await expect(listWorkflows.handler({
+        project_name: 'test_project',
+      })).rejects.toThrow('Failed to list workflows: API error');
+    });
+
+    it('should handle non-Error exceptions', async () => {
+      mockClient.listWorkflows.mockRejectedValue('String error');
+
+      await expect(listWorkflows.handler({
+        project_name: 'test_project',
+      })).rejects.toThrow('Failed to list workflows: String error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implement comprehensive MCP tools for monitoring Digdag workflow execution states and retrieving failure data based on the design document.

## Changes

### Client Implementation
- **WorkflowClient** (`src/client/workflow/`): Full-featured HTTP client for Digdag REST API
  - Automatic endpoint resolution based on TD site configuration
  - Support for all TD regions including staging/development environments
  - Proper error handling with API key masking
  - Timeout support (default 30s)

### MCP Tools (9 new tools)
1. **list_workflows** - List all workflows in a project with status
2. **list_sessions** - List workflow execution sessions with filtering
3. **get_session_attempts** - Get detailed attempt information
4. **get_attempt_tasks** - List tasks with execution status (failed tasks first)
5. **get_task_logs** - Retrieve logs for specific tasks with pagination
6. **get_attempt_logs** - Get aggregated logs with level filtering
7. **kill_attempt** - Cancel running attempts (requires TD_ENABLE_UPDATES=true)
8. **retry_session** - Retry failed sessions from beginning or specific task
9. **retry_attempt** - Retry specific attempts with resume capabilities

### Security Features
- API key masking in all error messages
- Read-only by default for monitoring operations
- Write operations (kill, retry) require explicit `TD_ENABLE_UPDATES=true`
- Follows existing security patterns from query/execute tools

### Testing
✅ **Comprehensive unit tests added** (59 new tests)
- 27 tests for client functionality (endpoints and HTTP operations)
- 32 tests for MCP tool handlers
- Coverage includes success cases, error handling, and edge cases
- All tests pass successfully

## Manual Testing
1. Set environment variables:
   ```bash
   export TD_API_KEY=your-api-key
   export TD_SITE=us01  # or jp01, eu01, ap02, ap03, dev
   export TD_ENABLE_UPDATES=true  # for retry/kill operations
   ```

2. Test workflow monitoring:
   ```
   list_workflows project_name:"your-project"
   list_sessions status:"error" limit:10
   get_attempt_tasks attempt_id:"123"
   ```

3. Test failure analysis:
   ```
   get_task_logs attempt_id:"123" task_name:"+main+failed_task"
   get_attempt_logs attempt_id:"123" level_filter:"ERROR"
   ```

## Related

- Design document: doc/design/2025-06-30-workflow-mcp-functions.md
- Issue: #68

🤖 Generated with [Claude Code](https://claude.ai/code)