### PR TITLE
fix: Fix list_workflows 404 error by using correct API endpoint

### DIFF
--- a/src/client/workflow/client.ts
+++ b/src/client/workflow/client.ts
@@ -89,21 +89,31 @@ export class WorkflowClient {
   }
 
   /**
-   * List all workflows in a project
+   * List all workflows, optionally filtered by project name
    */
   async listWorkflows(params: {
-    project_name: string;
+    project_name?: string;
     limit?: number;
     last_id?: string;
   }): Promise<WorkflowListResponse> {
-    return this.request<WorkflowListResponse>(
+    // API doesn't support project filtering, so we always request all workflows
+    const response = await this.request<WorkflowListResponse>(
       'GET',
-      `/api/projects/${encodeURIComponent(params.project_name)}/workflows`,
+      '/api/workflows',
       {
-        page_size: params.limit,
+        count: params.limit,
         last_id: params.last_id,
       }
     );
+
+    // Filter by project name if provided (client-side filtering)
+    if (params.project_name) {
+      response.workflows = response.workflows.filter(
+        wf => wf.project?.name === params.project_name
+      );
+    }
+
+    return response;
   }
 
   /**

--- a/src/tools/workflow/list-workflows.ts
+++ b/src/tools/workflow/list-workflows.ts
@@ -3,13 +3,13 @@ import { WorkflowClient } from '../../client/workflow/index.js';
 
 export const listWorkflows = {
   name: 'list_workflows',
-  description: 'List all workflows in a project with their current status',
+  description: 'List workflows. Optionally filter by project name.',
   inputSchema: {
     type: 'object',
     properties: {
       project_name: {
         type: 'string',
-        description: 'Name of the project',
+        description: 'Name of the project to filter by (optional)',
       },
       limit: {
         type: 'number',
@@ -20,18 +20,14 @@ export const listWorkflows = {
         description: 'Pagination cursor for next page',
       },
     },
-    required: ['project_name'],
+    required: [],
   },
   handler: async (args: unknown) => {
     const { project_name, limit = 100, last_id } = args as {
-      project_name: string;
+      project_name?: string;
       limit?: number;
       last_id?: string;
     };
-
-    if (!project_name) {
-      throw new Error('project_name is required');
-    }
 
     const config = loadConfig();
     const client = new WorkflowClient({

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -7,9 +7,13 @@ export type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG';
 export interface Workflow {
   id: string;
   name: string;
-  project: string;
+  project: {
+    id: string;
+    name: string;
+  };
   revision: string;
   timezone: string;
+  config?: Record<string, unknown>;
   last_session_time?: string;
   last_session_status?: WorkflowStatus;
 }

--- a/tests/client/workflow/client.test.ts
+++ b/tests/client/workflow/client.test.ts
@@ -50,8 +50,8 @@ describe('WorkflowClient', () => {
     it('should fetch workflows successfully', async () => {
       const mockResponse = {
         workflows: [
-          { id: '1', name: 'workflow1', project: 'test', revision: 'abc', timezone: 'UTC' },
-          { id: '2', name: 'workflow2', project: 'test', revision: 'def', timezone: 'UTC' },
+          { id: '1', name: 'workflow1', project: { id: '1', name: 'test' }, revision: 'abc', timezone: 'UTC' },
+          { id: '2', name: 'workflow2', project: { id: '1', name: 'test' }, revision: 'def', timezone: 'UTC' },
         ],
         next_page_id: 'next123',
       };
@@ -68,7 +68,7 @@ describe('WorkflowClient', () => {
 
       expect(result).toEqual(mockResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api-workflow.treasuredata.com/api/projects/test/workflows?page_size=10',
+        'https://api-workflow.treasuredata.com/api/workflows?count=10',
         expect.objectContaining({
           method: 'GET',
           headers: expect.objectContaining({
@@ -93,7 +93,7 @@ describe('WorkflowClient', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('page_size=50&last_id=last123'),
+        expect.stringContaining('count=50&last_id=last123'),
         expect.any(Object)
       );
     });

--- a/tests/integration/workflow-tools.integration.test.ts
+++ b/tests/integration/workflow-tools.integration.test.ts
@@ -103,9 +103,17 @@ describe.skipIf(!isIntegrationTest)('Workflow MCP Tools Integration Tests', () =
       }
     }, 30000);
 
-    it('should handle missing project_name parameter', async () => {
-      await expect(listWorkflows.handler({}))
-        .rejects.toThrow('project_name is required');
+    it('should list all workflows when project_name is not provided', async () => {
+      const result = await listWorkflows.handler({
+        limit: 10,
+      });
+
+      expect(result).toHaveProperty('workflows');
+      expect(result).toHaveProperty('count');
+      expect(Array.isArray(result.workflows)).toBe(true);
+      expect(result.count).toBe(result.workflows.length);
+      
+      console.log(`Found ${result.count} workflows when no project_name provided`);
     });
   });
 

--- a/tests/integration/workflow.integration.test.ts
+++ b/tests/integration/workflow.integration.test.ts
@@ -357,9 +357,12 @@ describe.skipIf(!isIntegrationTest)('Workflow Integration Tests', () => {
 
   describe('Error Handling', () => {
     it('should handle non-existent project gracefully', async () => {
-      await expect(client.listWorkflows({
+      // With client-side filtering, non-existent projects return empty array
+      const result = await client.listWorkflows({
         project_name: 'non_existent_project_12345',
-      })).rejects.toThrow(/404/);
+      });
+      
+      expect(result.workflows).toEqual([]);
     });
 
     it('should handle non-existent session gracefully', async () => {


### PR DESCRIPTION
## Summary
- Fixed issue #80 where `list_workflows(project_name: "xxx")` was returning 404 errors
- The `/api/workflows` endpoint doesn't support project filtering parameters
- Changed implementation to fetch all workflows and filter client-side

## Changes
1. **Updated Workflow type** - The API returns `project` as an object with `id` and `name` fields, not a string
2. **Fixed API endpoint usage** - Use `/api/workflows` without project parameter
3. **Corrected query parameters** - Use `count` instead of `page_size` for limiting results
4. **Client-side filtering** - Filter workflows by project name after fetching from API
5. **Made project_name optional** - Can now list all workflows or filter by project

## Testing
- All unit tests pass
- Manually tested:
  - Listing all workflows works
  - Filtering by existing project returns correct workflows
  - Filtering by non-existent project returns empty list

Fixes #80

🤖 Generated with [Claude Code](https://claude.ai/code)