### PR TITLE
Release v0.4.4: Mark workflow tools as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,9 @@ where (
 )
 ```
 
-### Workflow Tools - Monitor and Control Digdag Workflows
+### Workflow Tools (Experimental) - Monitor and Control Digdag Workflows
+
+> **Note**: These workflow tools are experimental and provide detailed access to workflow sessions, attempts, and tasks. They are subject to change in future releases.
 
 The following tools are available for monitoring and controlling Digdag workflows. These tools integrate with Treasure Data's workflow engine based on [Digdag](https://docs.digdag.io/api/):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treasuredata/mcp-server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "MCP server for Treasure Data - Query and interact with TD through Model Context Protocol",
   "main": "dist/index.js",
   "bin": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ export class TDMcpServer {
     this.server = new Server(
       {
         name: 'td-mcp-server',
-        version: '0.4.3',
+        version: '0.4.4',
       },
       {
         capabilities: {


### PR DESCRIPTION
## Summary
Mark workflow tools section as experimental in the README since they provide detailed functionality for checking workflow sessions and tasks.

## Changes
- Added experimental note to workflow tools section in README
- Bumped version to 0.4.4

## Rationale
These workflow tools provide very detailed access to workflow internals (sessions, attempts, tasks) and may be subject to change as we refine the API surface. Marking the section as experimental in the documentation sets proper expectations for users.

Note: The individual tool descriptions are not changed - only the section header in the README has been marked as experimental.

🤖 Generated with [Claude Code](https://claude.ai/code)